### PR TITLE
Add projectctl manifest dashboard

### DIFF
--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -22,6 +22,10 @@ import {
 } from './local-launcher-apps';
 import { getConnectorOverview } from './local-machine-registry';
 import {
+  getProjectctlOverview,
+  getProjectctlPreview
+} from './local-projectctl-client';
+import {
   backupProject,
   deployProject,
   getPlatformOverview
@@ -93,13 +97,28 @@ function createProjectRecord(
   groupId?: string
 ): ProjectSpaceRecord {
   const resolvedPath = resolve(path);
+  const hasProject = existsSync(join(resolvedPath, 'project.yaml'));
+  const hasLock = existsSync(join(resolvedPath, 'template.lock.yaml'));
+  const hasGoals = existsSync(join(resolvedPath, 'GOALS.md'));
+  const status =
+    hasProject && hasLock
+      ? 'managed'
+      : hasProject || hasLock || hasGoals
+        ? 'partial'
+        : 'unmanaged';
 
   return {
     id: makeNodeId(rootPath, resolvedPath),
     kind,
     groupId,
     name: basename(resolvedPath),
-    rootPath: resolvedPath
+    rootPath: resolvedPath,
+    projectctl: {
+      hasGoals,
+      hasLock,
+      hasProject,
+      status
+    }
   };
 }
 
@@ -524,6 +543,12 @@ export function createLocalProjectSpaceBackend(
     },
     async loadProjectDiscovery() {
       return discoverProjects();
+    },
+    async loadProjectctlOverview(projectPath: string) {
+      return getProjectctlOverview(projectPath);
+    },
+    async loadProjectctlPreview(projectPath: string) {
+      return getProjectctlPreview(projectPath);
     },
     async loadProjectsState() {
       return readProjectsState();

--- a/server/local-projectctl-client.ts
+++ b/server/local-projectctl-client.ts
@@ -1,0 +1,152 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import type {
+  ProjectctlInspectResult,
+  ProjectctlOverviewResult,
+  ProjectctlPlanResult
+} from '../src/shared/project-space-api';
+
+const execFileAsync = promisify(execFile);
+const projectctlSourceCandidates = [
+  join(homedir(), 'projects/fullstack-template'),
+  join(homedir(), 'projects/.worktrees/fullstack-template-projectctl-json')
+];
+
+interface ProjectctlCommand {
+  argsPrefix: string[];
+  command: string;
+  cwd?: string;
+  label: string;
+}
+
+interface ProjectctlRunResult<T> {
+  payload: T;
+  toolPath: string;
+}
+
+function localBinaryCandidates(): ProjectctlCommand[] {
+  const commands: ProjectctlCommand[] = [];
+
+  if (process.env.PROJECTCTL_PATH) {
+    commands.push({
+      argsPrefix: [],
+      command: process.env.PROJECTCTL_PATH,
+      label: process.env.PROJECTCTL_PATH
+    });
+  }
+
+  commands.push(
+    { argsPrefix: [], command: 'projectctl', label: 'projectctl' },
+    { argsPrefix: [], command: '/tmp/projectctl-json', label: '/tmp/projectctl-json' },
+    {
+      argsPrefix: [],
+      command: join(homedir(), '.local/bin/projectctl'),
+      label: join(homedir(), '.local/bin/projectctl')
+    }
+  );
+
+  for (const sourceRoot of projectctlSourceCandidates) {
+    if (existsSync(join(sourceRoot, 'cmd/projectctl/main.go'))) {
+      commands.push({
+        argsPrefix: ['run', './cmd/projectctl'],
+        command: 'go',
+        cwd: sourceRoot,
+        label: `${sourceRoot} via go run`
+      });
+    }
+  }
+
+  return commands;
+}
+
+function extractProcessOutput(error: unknown) {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'stdout' in error &&
+    typeof error.stdout === 'string'
+  ) {
+    return {
+      stderr:
+        'stderr' in error && typeof error.stderr === 'string'
+          ? error.stderr
+          : error instanceof Error
+            ? error.message
+            : '',
+      stdout: error.stdout
+    };
+  }
+
+  return {
+    stderr: error instanceof Error ? error.message : 'projectctl failed.',
+    stdout: ''
+  };
+}
+
+function parseJson<T>(stdout: string): T {
+  return JSON.parse(stdout) as T;
+}
+
+async function runProjectctlJson<T>(args: string[]): Promise<ProjectctlRunResult<T>> {
+  const errors: string[] = [];
+
+  for (const candidate of localBinaryCandidates()) {
+    try {
+      const { stdout } = await execFileAsync(candidate.command, [...candidate.argsPrefix, ...args], {
+        cwd: candidate.cwd,
+        windowsHide: true
+      });
+
+      return {
+        payload: parseJson<T>(stdout),
+        toolPath: candidate.label
+      };
+    } catch (error) {
+      const output = extractProcessOutput(error);
+
+      if (output.stdout.trim().startsWith('{')) {
+        return {
+          payload: parseJson<T>(output.stdout),
+          toolPath: candidate.label
+        };
+      }
+
+      errors.push(`${candidate.label}: ${output.stderr.trim() || 'no JSON output'}`);
+    }
+  }
+
+  throw new Error(`projectctl is not available. ${errors.join(' | ')}`);
+}
+
+export async function getProjectctlOverview(projectPath: string): Promise<ProjectctlOverviewResult> {
+  try {
+    const inspect = await runProjectctlJson<ProjectctlInspectResult>([
+      'inspect',
+      '--json',
+      projectPath
+    ]);
+    const status = await runProjectctlJson<ProjectctlPlanResult>(['status', '--json', projectPath])
+      .then((result) => result.payload)
+      .catch(() => undefined);
+
+    return {
+      available: true,
+      inspect: inspect.payload,
+      status,
+      toolPath: inspect.toolPath
+    };
+  } catch (error) {
+    return {
+      available: false,
+      error: error instanceof Error ? error.message : 'projectctl is not available.'
+    };
+  }
+}
+
+export async function getProjectctlPreview(projectPath: string): Promise<ProjectctlPlanResult> {
+  return (await runProjectctlJson<ProjectctlPlanResult>(['preview', '--json', projectPath])).payload;
+}

--- a/server/project-space-http.ts
+++ b/server/project-space-http.ts
@@ -137,6 +137,30 @@ function createApiHandler(backend: ProjectSpaceBackend) {
         return true;
       }
 
+      if (request.method === 'GET' && url.pathname === '/api/projectctl/overview') {
+        const projectPath = url.searchParams.get('projectPath');
+
+        if (!projectPath) {
+          writeJson(response, 400, { error: 'Missing projectPath.' });
+          return true;
+        }
+
+        writeJson(response, 200, await backend.loadProjectctlOverview(projectPath));
+        return true;
+      }
+
+      if (request.method === 'GET' && url.pathname === '/api/projectctl/preview') {
+        const projectPath = url.searchParams.get('projectPath');
+
+        if (!projectPath) {
+          writeJson(response, 400, { error: 'Missing projectPath.' });
+          return true;
+        }
+
+        writeJson(response, 200, await backend.loadProjectctlPreview(projectPath));
+        return true;
+      }
+
       if (request.method === 'POST' && url.pathname === '/api/projects/select-directory') {
         const selection: ProjectDirectorySelection = await backend.selectProjectDirectory();
         writeJson(response, 200, selection);

--- a/src/api/project-space-client.ts
+++ b/src/api/project-space-client.ts
@@ -19,6 +19,8 @@ import type {
   ProjectDirectorySelection,
   ProjectDiscoveryResult,
   ProjectSpaceBackend,
+  ProjectctlOverviewResult,
+  ProjectctlPlanResult,
   ProjectsState,
   ProjectWorktreeRecord,
   TerminalCommandRequest,
@@ -116,6 +118,18 @@ class HttpProjectSpaceClient implements ProjectSpaceBackend {
 
   loadProjectDiscovery(): Promise<ProjectDiscoveryResult> {
     return this.request('/api/projects/discovery');
+  }
+
+  loadProjectctlOverview(projectPath: string): Promise<ProjectctlOverviewResult> {
+    const query = new URLSearchParams({ projectPath });
+
+    return this.request(`/api/projectctl/overview?${query.toString()}`);
+  }
+
+  loadProjectctlPreview(projectPath: string): Promise<ProjectctlPlanResult> {
+    const query = new URLSearchParams({ projectPath });
+
+    return this.request(`/api/projectctl/preview?${query.toString()}`);
   }
 
   loadProjectsState(): Promise<ProjectsState> {

--- a/src/features/project-desktop/components/project-main-panel.tsx
+++ b/src/features/project-desktop/components/project-main-panel.tsx
@@ -7,6 +7,7 @@ import { Button, Card, Chip, Surface, Text } from '@heroui/react';
 import { OpenTargetDropdown } from './open-target-dropdown';
 import { ProjectOperationsPanel } from './project-operations-panel';
 import { ProjectWorkspaceTools } from './project-workspace-tools';
+import { ProjectctlManifestPanel } from './projectctl-manifest-panel';
 
 interface ProjectMainPanelProps {
   discoveryRoot: string;
@@ -120,6 +121,7 @@ export function ProjectMainPanel({
                 ) : null}
               </Card.Content>
             </Card>
+            <ProjectctlManifestPanel targetPath={selectedTargetPath} />
             <ProjectOperationsPanel projectName={project.name} targetPath={selectedTargetPath} />
             <ProjectWorkspaceTools targetPath={selectedTargetPath} />
           </div>

--- a/src/features/project-desktop/components/project-spaces-picker.tsx
+++ b/src/features/project-desktop/components/project-spaces-picker.tsx
@@ -3,6 +3,7 @@ import { Folder } from 'lucide-react';
 import {
   Accordion,
   Button,
+  Chip,
   ScrollShadow,
   SearchField,
   SearchFieldClearButton,
@@ -38,6 +39,18 @@ interface ProjectPickerSection {
 
 function matchesQuery(value: string, query: string) {
   return value.toLowerCase().includes(query.trim().toLowerCase());
+}
+
+function ProjectctlBadge({ project }: { project: ProjectSpaceRecord }) {
+  if (!project.projectctl || project.projectctl.status === 'unmanaged') {
+    return null;
+  }
+
+  return (
+    <Chip size="sm" variant={project.projectctl.status === 'managed' ? 'primary' : 'secondary'}>
+      {project.projectctl.status}
+    </Chip>
+  );
 }
 
 export function ProjectSpacesPicker({
@@ -308,6 +321,7 @@ export function ProjectSpacesPicker({
                                       WS
                                     </Text>
                                   ) : null}
+                                  <ProjectctlBadge project={project} />
                                 </div>
                               </Button>
                             </Tooltip.Trigger>
@@ -374,6 +388,7 @@ export function ProjectSpacesPicker({
                                               WS
                                             </Text>
                                           ) : null}
+                                          <ProjectctlBadge project={project} />
                                         </div>
                                       </Button>
                                     </Tooltip.Trigger>

--- a/src/features/project-desktop/components/projectctl-manifest-panel.tsx
+++ b/src/features/project-desktop/components/projectctl-manifest-panel.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Chip, ScrollShadow, Surface, Text } from '@heroui/react';
+import {
+  ClipboardList,
+  FileCheck2,
+  FileWarning,
+  GitCompareArrows,
+  RefreshCw,
+  Route
+} from 'lucide-react';
+import { projectSpaceClient } from '@/api/project-space-client';
+import type {
+  ProjectctlOverviewResult,
+  ProjectctlPlanOperation,
+  ProjectctlPlanResult
+} from '@/shared/project-space-api';
+
+interface ProjectctlManifestPanelProps {
+  targetPath: string;
+}
+
+function statusLabel(overview?: ProjectctlOverviewResult) {
+  if (!overview?.available) {
+    return 'tool missing';
+  }
+  if (!overview.inspect?.hasProject && !overview.inspect?.hasLock) {
+    return 'unmanaged';
+  }
+  if (overview.status?.conflictCount) {
+    return 'conflicts';
+  }
+  if (overview.status?.changes) {
+    return 'drift';
+  }
+  return 'in sync';
+}
+
+function statusVariant(label: string) {
+  if (label === 'in sync') {
+    return 'primary';
+  }
+  if (label === 'tool missing' || label === 'conflicts') {
+    return 'secondary';
+  }
+  return 'secondary';
+}
+
+function visibleOperations(plan?: ProjectctlPlanResult) {
+  return (plan?.operations ?? []).filter((operation) => operation.kind !== 'noop');
+}
+
+function firstNonEmpty(...values: Array<string | undefined>) {
+  return values.find((value) => value && value.trim().length > 0);
+}
+
+function OperationRow({ operation }: { operation: ProjectctlPlanOperation }) {
+  return (
+    <Surface
+      variant="tertiary"
+      className="grid grid-cols-[7rem_minmax(0,1fr)] items-center gap-3 rounded-md border border-slate-800 bg-black/20 px-3 py-2"
+    >
+      <Chip
+        size="sm"
+        variant="secondary"
+        className={operation.kind === 'conflict' ? 'border-amber-400/30 text-amber-300' : ''}
+      >
+        {operation.kind}
+      </Chip>
+      <div className="min-w-0">
+        <Text className="block truncate font-mono text-xs text-slate-200">{operation.path}</Text>
+        {operation.reason || operation.owner ? (
+          <Text className="block truncate text-xs text-slate-500">
+            {[operation.owner, operation.reason].filter(Boolean).join(' / ')}
+          </Text>
+        ) : null}
+      </div>
+    </Surface>
+  );
+}
+
+export function ProjectctlManifestPanel({ targetPath }: ProjectctlManifestPanelProps) {
+  const [overview, setOverview] = useState<ProjectctlOverviewResult>();
+  const [preview, setPreview] = useState<ProjectctlPlanResult>();
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+
+  async function refresh() {
+    if (!targetPath) {
+      return;
+    }
+    setIsLoading(true);
+    setError('');
+    try {
+      const nextOverview = await projectSpaceClient.loadProjectctlOverview(targetPath);
+      setOverview(nextOverview);
+      setPreview(nextOverview.preview);
+      if (nextOverview.error) {
+        setError(nextOverview.error);
+      }
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Could not load projectctl status.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function loadPreview() {
+    if (!targetPath) {
+      return;
+    }
+    setIsPreviewLoading(true);
+    setError('');
+    try {
+      setPreview(await projectSpaceClient.loadProjectctlPreview(targetPath));
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Could not preview projectctl changes.');
+    } finally {
+      setIsPreviewLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setPreview(undefined);
+    void refresh();
+  }, [targetPath]);
+
+  const label = statusLabel(overview);
+  const inspect = overview?.inspect;
+  const manifestProject = inspect?.project?.project ?? inspect?.lock?.project;
+  const presetName = firstNonEmpty(inspect?.project?.preset?.name, inspect?.lock?.preset?.name) ?? 'custom';
+  const templateVersion = firstNonEmpty(inspect?.lock?.template?.version, inspect?.templateVersion) ?? 'unknown';
+  const environments = inspect?.project?.environments ?? [];
+  const capabilities = inspect?.capabilities ?? inspect?.lock?.capabilities ?? [];
+  const features = inspect?.features ?? inspect?.lock?.features ?? {};
+  const missingMarkers = (inspect?.markers ?? []).filter((marker) => !marker.present);
+  const operations = visibleOperations(preview ?? overview?.status);
+  const enabledFeatureCount = useMemo(
+    () => Object.values(features).filter((feature) => feature.status === 'enabled').length,
+    [features]
+  );
+
+  return (
+    <Surface
+      variant="secondary"
+      className="grid shrink-0 gap-3 rounded-lg border border-slate-800 bg-slate-950/55 p-3 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)]"
+    >
+      <div className="grid min-w-0 gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <ClipboardList className="size-4 shrink-0 text-slate-400" />
+            <Text className="truncate text-sm font-semibold text-slate-100">Project Manifest</Text>
+          </div>
+          <div className="flex items-center gap-2">
+            <Chip size="sm" variant={statusVariant(label)}>
+              {label}
+            </Chip>
+            <Button
+              size="sm"
+              variant="ghost"
+              isDisabled={!targetPath || isLoading}
+              onPress={() => void refresh()}
+            >
+              <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          <Surface variant="tertiary" className="rounded-lg border border-slate-800 bg-black/20 p-3">
+            <Text className="block text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Kind
+            </Text>
+            <Text className="mt-1 block truncate text-sm text-slate-100">
+              {manifestProject?.kind ?? 'unknown'}
+            </Text>
+          </Surface>
+          <Surface variant="tertiary" className="rounded-lg border border-slate-800 bg-black/20 p-3">
+            <Text className="block text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Preset
+            </Text>
+            <Text className="mt-1 block truncate text-sm text-slate-100">{presetName}</Text>
+          </Surface>
+          <Surface variant="tertiary" className="rounded-lg border border-slate-800 bg-black/20 p-3">
+            <Text className="block text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Template
+            </Text>
+            <Text className="mt-1 block truncate font-mono text-sm text-slate-100">
+              {templateVersion}
+            </Text>
+          </Surface>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {environments.length > 0 ? (
+            environments.map((environment) => (
+              <Chip key={environment.name} size="sm" variant={environment.default ? 'primary' : 'secondary'}>
+                {environment.name}
+              </Chip>
+            ))
+          ) : (
+            <Chip size="sm" variant="tertiary">
+              no environments
+            </Chip>
+          )}
+          <Chip size="sm" variant="secondary">
+            {enabledFeatureCount} enabled features
+          </Chip>
+          <Chip size="sm" variant={inspect?.hasGoals ? 'primary' : 'secondary'}>
+            GOALS.md
+          </Chip>
+        </div>
+
+        {error ? (
+          <Surface
+            variant="tertiary"
+            className="rounded-lg border border-amber-400/20 bg-amber-500/8 px-4 py-3 text-sm text-amber-300"
+          >
+            {error}
+          </Surface>
+        ) : null}
+      </div>
+
+      <div className="grid min-w-0 gap-3">
+        <div className="flex items-center gap-2">
+          <GitCompareArrows className="size-4 shrink-0 text-slate-400" />
+          <Text className="truncate text-sm font-semibold text-slate-100">Standard Drift</Text>
+          <div className="ml-auto flex items-center gap-2">
+            <Chip size="sm" variant={preview?.changes ? 'secondary' : 'primary'}>
+              {preview ? preview.summary : overview?.status?.summary ?? 'not checked'}
+            </Chip>
+            <Button
+              size="sm"
+              variant="outline"
+              isDisabled={!targetPath || !overview?.available || !overview.inspect?.hasProject || isPreviewLoading}
+              onPress={() => void loadPreview()}
+            >
+              <Route className={`size-4 ${isPreviewLoading ? 'animate-spin' : ''}`} />
+              Preview
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <Surface variant="tertiary" className="min-h-32 rounded-lg border border-slate-800 bg-black/20 p-3">
+            <div className="mb-2 flex items-center gap-2">
+              <FileCheck2 className="size-4 text-slate-400" />
+              <Text className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Capabilities
+              </Text>
+            </div>
+            <ScrollShadow className="max-h-28" hideScrollBar>
+              <div className="flex flex-wrap gap-2">
+                {capabilities.length > 0 ? (
+                  capabilities.map((capability) => (
+                    <Chip key={capability} size="sm" variant="secondary">
+                      {capability}
+                    </Chip>
+                  ))
+                ) : (
+                  <Text className="text-sm text-slate-500">No capabilities recorded yet.</Text>
+                )}
+              </div>
+            </ScrollShadow>
+          </Surface>
+
+          <Surface variant="tertiary" className="min-h-32 rounded-lg border border-slate-800 bg-black/20 p-3">
+            <div className="mb-2 flex items-center gap-2">
+              <FileWarning className="size-4 text-slate-400" />
+              <Text className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Missing
+              </Text>
+            </div>
+            <ScrollShadow className="max-h-28" hideScrollBar>
+              <div className="grid gap-2">
+                {missingMarkers.length > 0 ? (
+                  missingMarkers.slice(0, 6).map((marker) => (
+                    <Text key={marker.path} className="truncate font-mono text-xs text-slate-400">
+                      {marker.path}
+                    </Text>
+                  ))
+                ) : (
+                  <Text className="text-sm text-slate-500">All tracked markers are present.</Text>
+                )}
+              </div>
+            </ScrollShadow>
+          </Surface>
+        </div>
+
+        {operations.length > 0 ? (
+          <ScrollShadow className="max-h-44" hideScrollBar>
+            <div className="grid gap-2">
+              {operations.map((operation) => (
+                <OperationRow key={`${operation.kind}:${operation.path}`} operation={operation} />
+              ))}
+            </div>
+          </ScrollShadow>
+        ) : (
+          <Surface
+            variant="tertiary"
+            className="rounded-lg border border-slate-800 bg-black/20 px-3 py-2 text-sm text-slate-500"
+          >
+            No planned file changes.
+          </Surface>
+        )}
+      </div>
+    </Surface>
+  );
+}

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -12,12 +12,20 @@ export interface ProjectDirectorySelection {
   name?: string;
 }
 
+export interface ProjectctlDiscoverySummary {
+  hasGoals: boolean;
+  hasLock: boolean;
+  hasProject: boolean;
+  status: 'managed' | 'partial' | 'unmanaged';
+}
+
 export interface ProjectSpaceRecord {
   id: string;
   name: string;
   rootPath: string;
   kind: 'workspace' | 'standalone';
   groupId?: string;
+  projectctl?: ProjectctlDiscoverySummary;
 }
 
 export interface ProjectGroupRecord {
@@ -302,6 +310,113 @@ export interface ProjectBackupRequest {
   target: string;
 }
 
+export interface ProjectctlPresenceReport {
+  label: string;
+  path: string;
+  present: boolean;
+}
+
+export interface ProjectctlCheckItem {
+  command?: string;
+  files?: string[];
+  notes?: string[];
+  path?: string;
+  runtime?: string;
+  status: string;
+}
+
+export interface ProjectctlProjectSettings {
+  bundleId?: string;
+  displayName: string;
+  kind: string;
+  modulePath?: string;
+  name: string;
+  port?: number;
+  slug: string;
+}
+
+export interface ProjectctlEnvironmentConfig {
+  default?: boolean;
+  name: string;
+  purpose: string;
+}
+
+export interface ProjectctlInspectResult {
+  capabilities?: string[];
+  features?: Record<string, ProjectctlCheckItem>;
+  hasGoals: boolean;
+  hasLock: boolean;
+  hasProject: boolean;
+  lock?: {
+    addons?: Record<string, { status: string }>;
+    capabilities?: string[];
+    features?: Record<string, ProjectctlCheckItem>;
+    migration?: {
+      appliedMigrations?: string[];
+      lastAppliedVersion?: string;
+      notes?: string[];
+    };
+    platforms?: Record<string, ProjectctlCheckItem>;
+    preset?: {
+      name: string;
+      version: string;
+    };
+    project?: {
+      backend?: string;
+      bundleId?: string;
+      displayName: string;
+      kind: string;
+      modulePath?: string;
+      slug: string;
+    };
+    template?: {
+      generator: string;
+      repository: string;
+      version: string;
+    };
+  };
+  markers: ProjectctlPresenceReport[];
+  project?: {
+    addons?: Record<string, { enabled: boolean }>;
+    environments?: ProjectctlEnvironmentConfig[];
+    preset?: {
+      disabled?: string[];
+      name: string;
+      options?: Record<string, unknown>;
+      version: string;
+    };
+    project: ProjectctlProjectSettings;
+  };
+  root: string;
+  templateVersion: string;
+}
+
+export interface ProjectctlPlanOperation {
+  kind: string;
+  owner?: string;
+  path: string;
+  reason?: string;
+}
+
+export interface ProjectctlPlanResult {
+  changes: boolean;
+  conflictCount: number;
+  counts: Record<string, number>;
+  operations: ProjectctlPlanOperation[];
+  root: string;
+  summary: string;
+  templateVersion: string;
+}
+
+export interface ProjectctlOverviewResult {
+  available: boolean;
+  error?: string;
+  inspect?: ProjectctlInspectResult;
+  preview?: ProjectctlPlanResult;
+  status?: ProjectctlPlanResult;
+  toolPath?: string;
+}
+
 export interface ProjectSpaceBackend {
   getAppMeta(): Promise<AppMeta>;
   getCodexStatus(): Promise<CodexStatusResult>;
@@ -312,6 +427,8 @@ export interface ProjectSpaceBackend {
   loadLauncherAppIcon(appId: string): Promise<string | undefined>;
   loadLauncherApps(): Promise<LauncherAppRecord[]>;
   loadProjectDiscovery(): Promise<ProjectDiscoveryResult>;
+  loadProjectctlOverview(projectPath: string): Promise<ProjectctlOverviewResult>;
+  loadProjectctlPreview(projectPath: string): Promise<ProjectctlPlanResult>;
   loadProjectsState(): Promise<ProjectsState>;
   loadProjectWorktrees(projectPath: string): Promise<ProjectWorktreeRecord[]>;
   openCodexSkills(): Promise<OpenPathInAppResult>;


### PR DESCRIPTION
Adds first-level projectctl integration to Project Space.\n\nWhat changed:\n- Project discovery marks projects as managed, partial, or unmanaged based on project.yaml/template.lock.yaml/GOALS.md.\n- New Project Manifest panel shows kind, preset, template version, environments, capabilities, missing markers, and drift status for the selected project.\n- Backend exposes projectctl overview and preview endpoints backed by projectctl JSON output.\n\nVerification:\n- pnpm run check\n- pnpm run build\n- PROJECTCTL_PATH=/tmp/projectctl-json pnpm start\n- curl /api/projectctl/overview for /Users/oli/projects/daily\n- curl /api/projectctl/preview for /Users/oli/projects/daily\n- Headless Chrome screenshot of the Project Space dashboard with daily selected