### PR TITLE
Improve tmp project creation output

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,6 +91,7 @@ func newCreateCommand() *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "Installed module: %s\n", plan.Module)
 				}
 			}
+			fmt.Fprintf(cmd.OutOrStdout(), "cd %s\n", shellQuote(resolved))
 			return nil
 		},
 	}
@@ -100,17 +103,40 @@ func newCreateCommand() *cobra.Command {
 }
 
 func tmpProjectTarget(name string, global bool) (string, error) {
+	suffix, err := randomSuffix()
+	if err != nil {
+		return "", err
+	}
 	if name == "" {
 		name = "generated-app"
 	}
-	base := name
-	if filepath.IsAbs(name) {
-		base = filepath.Base(name)
+	base := filepath.Base(filepath.Clean(name))
+	if base == "." || base == string(filepath.Separator) {
+		base = "generated-app"
 	}
+	base = base + "-" + suffix
 	if global {
 		return filepath.Join("/tmp", "project-"+base), nil
 	}
 	return filepath.Join("tmp", base), nil
+}
+
+func randomSuffix() (string, error) {
+	bytes := make([]byte, 4)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("generate tmp project suffix: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(value, " \t\n'\"\\$&;()[]{}!*?<>|`") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func newInitCommand() *cobra.Command {

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -23,11 +23,11 @@ Useful flags:
 --global-tmp
 ```
 
-`--tmp` creates `./tmp/generated-app`, writes tmp template values, and installs the template's default modules.
+`--tmp` creates `./tmp/generated-app-<suffix>`, writes tmp template values, and installs the template's default modules.
 
 `--local-tmp` is the explicit form of `--tmp`.
 
-`--global-tmp` creates the generated project under `/tmp`.
+`--global-tmp` creates the generated project under `/tmp` with a random suffix.
 
 Example:
 


### PR DESCRIPTION
## Summary
- Print a copy-paste-ready cd command after project creation
- Give --tmp and --global-tmp projects a random suffix so repeated runs do not collide
- Document the random tmp project naming

## Verification
- go test ./...
- pnpm run check
- project new --tmp twice creates two different directories
- project new with spaces in the path prints a quoted cd command
- project validate on a generated tmp project