### PR TITLE
Add module remove and confirmation flow

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -184,7 +185,8 @@ func newModuleCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newModuleListCommand())
 	cmd.AddCommand(newModuleShowCommand())
-	cmd.AddCommand(newModuleInstallCommand())
+	cmd.AddCommand(newModuleAddCommand())
+	cmd.AddCommand(newModuleRemoveCommand())
 	return cmd
 }
 
@@ -257,13 +259,16 @@ func newModuleShowCommand() *cobra.Command {
 	return cmd
 }
 
-func newModuleInstallCommand() *cobra.Command {
-	options := projectvalidator.ModuleInstallOptions{}
+func newModuleAddCommand() *cobra.Command {
+	dryRun := false
+	force := false
 	format := "pretty"
+	yes := false
+	legacyApply := false
 	cmd := &cobra.Command{
-		Use:               "install <module> [project-directory]",
-		Aliases:           []string{"add"},
-		Short:             "Plan or install a project template module",
+		Use:               "add <module> [project-directory]",
+		Aliases:           []string{"install"},
+		Short:             "Add a project template module",
 		Args:              cobra.RangeArgs(1, 2),
 		ValidArgsFunction: moduleInstallCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -275,27 +280,115 @@ func newModuleInstallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if options.Apply && options.DryRun {
-				return fmt.Errorf("--apply and --dry-run cannot be used together")
+			if legacyApply {
+				yes = true
 			}
-			if !options.Apply && !options.DryRun {
-				return fmt.Errorf("choose --dry-run to preview changes or --apply to write them")
+			if yes && dryRun {
+				return fmt.Errorf("--yes and --dry-run cannot be used together")
 			}
 			if format != "pretty" && format != "tsv" {
 				return fmt.Errorf("unknown format %q; use pretty or tsv", format)
 			}
-			plan, err := projectvalidator.InstallModule(resolved, args[0], options)
+			if format == "tsv" && !dryRun && !yes {
+				return fmt.Errorf("use --dry-run or --yes with --format tsv")
+			}
+
+			plan, err := projectvalidator.InstallModule(resolved, args[0], projectvalidator.ModuleInstallOptions{Force: force})
 			if err != nil {
 				return err
 			}
-			printModuleInstallPlan(cmd, plan, options, format)
+			displayOptions := projectvalidator.ModuleInstallOptions{Apply: yes, DryRun: dryRun, Force: force}
+			printModuleInstallPlan(cmd, plan, displayOptions, format)
+			if dryRun || len(plan.ToInstall) == 0 {
+				return nil
+			}
+			if !yes {
+				confirmed, err := confirmApply(cmd)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					printModuleCanceled(cmd, format)
+					return nil
+				}
+			}
+			applied, err := projectvalidator.InstallModule(resolved, args[0], projectvalidator.ModuleInstallOptions{Apply: true, Force: force})
+			if err != nil {
+				return err
+			}
+			printModuleApplied(cmd, applied.LockPath, format)
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&options.Apply, "apply", false, "write the module install plan to the project lock")
-	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "show the module install plan without writing changes")
-	cmd.Flags().BoolVar(&options.Force, "force", false, "allow module install to overwrite existing project files")
+	cmd.Flags().BoolVar(&legacyApply, "apply", false, "write the module add plan without prompting")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the module add plan without writing changes")
+	cmd.Flags().BoolVar(&force, "force", false, "allow module add to overwrite existing project files")
 	cmd.Flags().StringVar(&format, "format", "pretty", "output format")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply the module add plan without prompting")
+	must(cmd.Flags().MarkHidden("apply"))
+	must(cmd.Flags().MarkDeprecated("apply", "use --yes instead"))
+	must(cmd.RegisterFlagCompletionFunc("format", fixedValuesCompletion("pretty", "tsv")))
+	return cmd
+}
+
+func newModuleRemoveCommand() *cobra.Command {
+	dryRun := false
+	format := "pretty"
+	yes := false
+	cmd := &cobra.Command{
+		Use:               "remove <module> [project-directory]",
+		Short:             "Remove a project template module",
+		Args:              cobra.RangeArgs(1, 2),
+		ValidArgsFunction: moduleInstallCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := "."
+			if len(args) == 2 {
+				target = args[1]
+			}
+			resolved, err := filepath.Abs(target)
+			if err != nil {
+				return err
+			}
+			if yes && dryRun {
+				return fmt.Errorf("--yes and --dry-run cannot be used together")
+			}
+			if format != "pretty" && format != "tsv" {
+				return fmt.Errorf("unknown format %q; use pretty or tsv", format)
+			}
+			if format == "tsv" && !dryRun && !yes {
+				return fmt.Errorf("use --dry-run or --yes with --format tsv")
+			}
+
+			plan, err := projectvalidator.RemoveModule(resolved, args[0], projectvalidator.ModuleRemoveOptions{})
+			if err != nil {
+				return err
+			}
+			displayOptions := projectvalidator.ModuleRemoveOptions{Apply: yes, DryRun: dryRun}
+			printModuleRemovePlan(cmd, plan, displayOptions, format)
+			if dryRun || len(plan.ToRemove) == 0 {
+				return nil
+			}
+			if !yes {
+				confirmed, err := confirmApply(cmd)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					printModuleCanceled(cmd, format)
+					return nil
+				}
+			}
+			applied, err := projectvalidator.RemoveModule(resolved, args[0], projectvalidator.ModuleRemoveOptions{Apply: true})
+			if err != nil {
+				return err
+			}
+			printModuleApplied(cmd, applied.LockPath, format)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the module remove plan without writing changes")
+	cmd.Flags().StringVar(&format, "format", "pretty", "output format")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply the module remove plan without prompting")
 	must(cmd.RegisterFlagCompletionFunc("format", fixedValuesCompletion("pretty", "tsv")))
 	return cmd
 }
@@ -329,8 +422,10 @@ func printModuleInstallPlan(cmd *cobra.Command, plan projectvalidator.ModuleInst
 	mode := "DRY-RUN"
 	if options.Apply {
 		mode = "APPLY"
+	} else if !options.DryRun {
+		mode = "CONFIRM"
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Module install plan\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "Module add plan\n")
 	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", plan.ProjectRoot)
 	fmt.Fprintf(cmd.OutOrStdout(), "Mode: %s\n\n", strings.ToLower(mode))
 
@@ -357,19 +452,25 @@ func printModuleInstallPlan(cmd *cobra.Command, plan projectvalidator.ModuleInst
 		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: no module changes")
 		return
 	}
-	if !options.Apply {
+	if options.DryRun {
 		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: dry run, no changes written")
 		return
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "\nResult: applied\nLock: %s\n", plan.LockPath)
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: applying")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nResult: waiting for confirmation")
 }
 
 func printModuleInstallPlanTSV(cmd *cobra.Command, plan projectvalidator.ModuleInstallPlan, options projectvalidator.ModuleInstallOptions) {
 	mode := "dry_run"
 	if options.Apply {
 		mode = "apply"
+	} else if !options.DryRun {
+		mode = "confirm"
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "PLAN\tmodule_install\t%s\t%s\n", mode, plan.ProjectRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "PLAN\tmodule_add\t%s\t%s\n", mode, plan.ProjectRoot)
 	for _, module := range plan.AlreadyInstalled {
 		fmt.Fprintf(cmd.OutOrStdout(), "KEEP\tmodule\t%s\t.\n", module)
 	}
@@ -383,11 +484,107 @@ func printModuleInstallPlanTSV(cmd *cobra.Command, plan projectvalidator.ModuleI
 		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tok\t.\tno module changes")
 		return
 	}
-	if !options.Apply {
+	if options.DryRun {
 		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tdry_run\t.\tno changes written")
 		return
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "RESULT\tapplied\t%s\tlock updated\n", plan.LockPath)
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tapply\t.\tapplying")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tconfirm\t.\twaiting for confirmation")
+}
+
+func printModuleRemovePlan(cmd *cobra.Command, plan projectvalidator.ModuleRemovePlan, options projectvalidator.ModuleRemoveOptions, format string) {
+	if format == "tsv" {
+		printModuleRemovePlanTSV(cmd, plan, options)
+		return
+	}
+
+	mode := "DRY-RUN"
+	if options.Apply {
+		mode = "APPLY"
+	} else if !options.DryRun {
+		mode = "CONFIRM"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Module remove plan\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", plan.ProjectRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Mode: %s\n\n", strings.ToLower(mode))
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Modules")
+	for _, module := range plan.ToRemove {
+		fmt.Fprintf(cmd.OutOrStdout(), "  - %s\n", module)
+	}
+	if len(plan.ToRemove) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no module changes")
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "\nFiles")
+	for _, file := range plan.Files {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s %-40s %s\n", moduleFileActionSymbol(file.Action), file.Path, file.Module)
+	}
+	if len(plan.Files) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no file changes")
+	}
+
+	if len(plan.ToRemove) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: no module changes")
+		return
+	}
+	if options.DryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: dry run, no changes written")
+		return
+	}
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: applying")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nResult: waiting for confirmation")
+}
+
+func printModuleRemovePlanTSV(cmd *cobra.Command, plan projectvalidator.ModuleRemovePlan, options projectvalidator.ModuleRemoveOptions) {
+	mode := "dry_run"
+	if options.Apply {
+		mode = "apply"
+	} else if !options.DryRun {
+		mode = "confirm"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "PLAN\tmodule_remove\t%s\t%s\n", mode, plan.ProjectRoot)
+	for _, module := range plan.ToRemove {
+		fmt.Fprintf(cmd.OutOrStdout(), "DELETE\tmodule\t%s\t.\n", module)
+	}
+	for _, file := range plan.Files {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\tfile\t%s\t%s\n", file.Action, file.Path, file.Module)
+	}
+	if len(plan.ToRemove) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tok\t.\tno module changes")
+		return
+	}
+	if options.DryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tdry_run\t.\tno changes written")
+		return
+	}
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tapply\t.\tapplying")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tconfirm\t.\twaiting for confirmation")
+}
+
+func printModuleApplied(cmd *cobra.Command, lockPath string, format string) {
+	if format == "tsv" {
+		fmt.Fprintf(cmd.OutOrStdout(), "RESULT\tapplied\t%s\tlock updated\n", lockPath)
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Result: applied\nLock: %s\n", lockPath)
+}
+
+func printModuleCanceled(cmd *cobra.Command, format string) {
+	if format == "tsv" {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tcanceled\t.\tno changes written")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Result: canceled, no changes written")
 }
 
 func moduleFileActionSymbol(action string) string {
@@ -396,9 +593,24 @@ func moduleFileActionSymbol(action string) string {
 		return "+"
 	case "OVERWRITE":
 		return "!"
+	case "DELETE":
+		return "-"
 	default:
 		return strings.ToLower(action)
 	}
+}
+
+func confirmApply(cmd *cobra.Command) (bool, error) {
+	fmt.Fprint(cmd.OutOrStdout(), "Apply changes? Y/n: ")
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("confirmation required; rerun with --yes or --dry-run")
+	}
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	return answer == "" || answer == "y" || answer == "yes", nil
 }
 
 func printModuleShow(cmd *cobra.Command, projectRoot string, module projectvalidator.ModuleInfo, format string) {

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -63,14 +63,23 @@ project init [project-directory]
 ```sh
 project module list [project-directory]
 project module show <module> [project-directory]
+project module add <module> [project-directory]
 project module add <module> [project-directory] --dry-run
-project module add <module> [project-directory] --apply
+project module add <module> [project-directory] --yes
+project module remove <module> [project-directory]
+project module remove <module> [project-directory] --dry-run
+project module remove <module> [project-directory] --yes
 project module add <module> [project-directory] --dry-run --format tsv
+project module remove <module> [project-directory] --dry-run --format tsv
 ```
 
-`module add` and `module install` are aliases.
+`module add` prints the planned changes, then asks for confirmation.
 
-Module installs require either `--dry-run` or `--apply`.
+Use `--dry-run` to only preview changes.
+
+Use `-y` or `--yes` to apply without prompting.
+
+`module install` is kept as an alias for `module add`.
 
 ## Validate
 

--- a/internal/projectvalidator/modules.go
+++ b/internal/projectvalidator/modules.go
@@ -79,6 +79,61 @@ func InstallModule(projectRoot string, moduleName string, options ModuleInstallO
 	return plan, nil
 }
 
+func RemoveModule(projectRoot string, moduleName string, options ModuleRemoveOptions) (ModuleRemovePlan, error) {
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	lock, err := readTemplateLock(root)
+	if err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	template, err := loadTemplate(root, lock)
+	if err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	if len(template.Modules) == 0 {
+		return ModuleRemovePlan{}, fmt.Errorf("template %s does not define modules yet", template.Name)
+	}
+	if _, ok := template.Modules[moduleName]; !ok {
+		return ModuleRemovePlan{}, fmt.Errorf("unknown module %q", moduleName)
+	}
+
+	installed := installedModuleSet(lock.Modules)
+	plan := ModuleRemovePlan{ProjectRoot: root, Module: moduleName}
+	if !installed[moduleName] {
+		return plan, nil
+	}
+
+	blockedBy := moduleDependents(template.Modules, lock.Modules, moduleName)
+	if len(blockedBy) > 0 {
+		plan.BlockedBy = blockedBy
+		return plan, fmt.Errorf("module %s is required by installed modules: %s", moduleName, strings.Join(blockedBy, ", "))
+	}
+
+	plan.ToRemove = []string{moduleName}
+	files, err := moduleRemoveFiles(root, template, moduleName, lock.Modules)
+	if err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	plan.Files = files
+	plan.WouldWrite = true
+	if !options.Apply || options.DryRun {
+		return plan, nil
+	}
+
+	if err := removeModuleFiles(root, plan.Files); err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	lock.Modules = removeModuleName(lock.Modules, moduleName)
+	lockPath, err := writeTemplateLock(root, lock)
+	if err != nil {
+		return ModuleRemovePlan{}, err
+	}
+	plan.LockPath = lockPath
+	return plan, nil
+}
+
 func applyModuleFiles(projectRoot string, template TemplateSpec, values TemplateValues, files []ModuleInstallFile) error {
 	for _, file := range files {
 		fileSpec, ok := template.Files[file.Path]
@@ -103,6 +158,31 @@ func applyModuleFiles(projectRoot string, template TemplateSpec, values Template
 		}
 	}
 	return nil
+}
+
+func removeModuleFiles(projectRoot string, files []ModuleInstallFile) error {
+	for _, file := range files {
+		if file.Action != "DELETE" {
+			continue
+		}
+		targetPath := filepath.Join(projectRoot, filepath.FromSlash(file.Path))
+		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		removeEmptyParents(projectRoot, filepath.Dir(targetPath))
+	}
+	return nil
+}
+
+func removeEmptyParents(projectRoot string, dir string) {
+	root := filepath.Clean(projectRoot)
+	current := filepath.Clean(dir)
+	for current != root && strings.HasPrefix(current, root+string(filepath.Separator)) {
+		if err := os.Remove(current); err != nil {
+			return
+		}
+		current = filepath.Dir(current)
+	}
 }
 
 func ListModules(projectRoot string) ([]string, error) {
@@ -189,6 +269,39 @@ func moduleInstallFiles(projectRoot string, template TemplateSpec, modules []str
 	return installFiles, conflicts, nil
 }
 
+func moduleRemoveFiles(projectRoot string, template TemplateSpec, moduleName string, installedModules []string) ([]ModuleInstallFile, error) {
+	files, err := moduleTemplateFiles(template, moduleName)
+	if err != nil {
+		return nil, err
+	}
+	remaining := removeModuleName(installedModules, moduleName)
+	ownedByRemaining := map[string]bool{}
+	for _, remainingModule := range remaining {
+		remainingFiles, err := moduleTemplateFiles(template, remainingModule)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range remainingFiles {
+			ownedByRemaining[path] = true
+		}
+	}
+
+	removeFiles := []ModuleInstallFile{}
+	for _, path := range files {
+		if ownedByRemaining[path] {
+			continue
+		}
+		projectPath := filepath.Join(projectRoot, filepath.FromSlash(path))
+		if stat, err := os.Stat(projectPath); err == nil && !stat.IsDir() {
+			removeFiles = append(removeFiles, ModuleInstallFile{Action: "DELETE", Module: moduleName, Path: path})
+		}
+	}
+	sort.Slice(removeFiles, func(i, j int) bool {
+		return removeFiles[i].Path < removeFiles[j].Path
+	})
+	return removeFiles, nil
+}
+
 func moduleTemplateFiles(template TemplateSpec, moduleName string) ([]string, error) {
 	module, ok := template.Modules[moduleName]
 	if !ok {
@@ -228,6 +341,24 @@ func formatModuleConflicts(conflicts []ModuleInstallConflict) string {
 		parts = append(parts, conflict.Path+" ("+conflict.Module+")")
 	}
 	return strings.Join(parts, ", ")
+}
+
+func moduleDependents(modules map[string]TemplateModuleSpec, installedModules []string, moduleName string) []string {
+	dependents := []string{}
+	for _, installed := range installedModules {
+		if installed == moduleName {
+			continue
+		}
+		module := modules[installed]
+		for _, dependency := range module.DependsOn {
+			if dependency == moduleName {
+				dependents = append(dependents, installed)
+				break
+			}
+		}
+	}
+	sort.Strings(dependents)
+	return dependents
 }
 
 func installedModuleSet(modules []string) map[string]bool {
@@ -283,4 +414,15 @@ func uniqueSortedModules(modules []string) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func removeModuleName(modules []string, moduleName string) []string {
+	result := []string{}
+	for _, module := range modules {
+		if module == moduleName {
+			continue
+		}
+		result = append(result, module)
+	}
+	return uniqueSortedModules(result)
 }

--- a/internal/projectvalidator/types.go
+++ b/internal/projectvalidator/types.go
@@ -42,6 +42,11 @@ type ModuleInstallOptions struct {
 	DryRun bool
 }
 
+type ModuleRemoveOptions struct {
+	Apply  bool
+	DryRun bool
+}
+
 type ModuleInstallPlan struct {
 	ProjectRoot      string
 	Module           string
@@ -51,6 +56,16 @@ type ModuleInstallPlan struct {
 	Conflicts        []ModuleInstallConflict
 	WouldWrite       bool
 	LockPath         string
+}
+
+type ModuleRemovePlan struct {
+	ProjectRoot string
+	Module      string
+	ToRemove    []string
+	Files       []ModuleInstallFile
+	BlockedBy   []string
+	WouldWrite  bool
+	LockPath    string
 }
 
 type ModuleInstallFile struct {


### PR DESCRIPTION
## Summary
- Make project module add the primary module install command
- Add project module remove
- Show the plan first, then ask Apply changes? Y/n by default
- Add -y/--yes to apply without prompting
- Keep --dry-run and --format tsv for preview/script use

## Verification
- go test ./...
- pnpm run check
- project module help shows add/remove
- project module add core.repo with n cancels
- project module add core.repo with Enter applies
- project module add core.repo --yes --format tsv applies
- project module remove core.repo --dry-run
- project module remove core.repo --yes
- removing a dependency required by another installed module is blocked
- project validate generated tmp project