### PR TITLE
Add template sync dry run

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -701,6 +701,7 @@ func newTemplateCommand() *cobra.Command {
 
 func newTemplateSyncCommand() *cobra.Command {
 	options := projectvalidator.TemplateSyncOptions{}
+	format := "pretty"
 	cmd := &cobra.Command{
 		Use:               "sync [project-directory]",
 		Short:             "Sync the local template snapshot",
@@ -715,18 +716,78 @@ func newTemplateSyncCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if format != "pretty" && format != "tsv" {
+				return fmt.Errorf("unknown format %q; use pretty or tsv", format)
+			}
+			if options.DryRun {
+				plan, err := projectvalidator.PlanTemplateSync(resolved, options)
+				if err != nil {
+					return err
+				}
+				printTemplateSyncPlan(cmd, plan, options, format)
+				return nil
+			}
 			templatePath, checksum, err := projectvalidator.SyncTemplate(resolved, options)
 			if err != nil {
 				return err
+			}
+			if format == "tsv" {
+				fmt.Fprintf(cmd.OutOrStdout(), "RESULT\tapplied\t%s\t%s\n", templatePath, checksum)
+				return nil
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Synced project template: %s\n", templatePath)
 			fmt.Fprintf(cmd.OutOrStdout(), "Checksum: %s\n", checksum)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "show the template sync plan without writing changes")
+	cmd.Flags().StringVar(&format, "format", "pretty", "output format")
 	cmd.Flags().StringVar(&options.TemplatePath, "template-path", "", "template source path")
+	must(cmd.RegisterFlagCompletionFunc("format", fixedValuesCompletion("pretty", "tsv")))
 	must(cmd.RegisterFlagCompletionFunc("template-path", directoryCompletion))
 	return cmd
+}
+
+func printTemplateSyncPlan(cmd *cobra.Command, plan projectvalidator.TemplateSyncPlan, options projectvalidator.TemplateSyncOptions, format string) {
+	if format == "tsv" {
+		fmt.Fprintf(cmd.OutOrStdout(), "PLAN\ttemplate_sync\tdry_run\t%s\n", plan.ProjectRoot)
+		fmt.Fprintf(cmd.OutOrStdout(), "SOURCE\tdir\t%s\t.\n", plan.SourceRoot)
+		fmt.Fprintf(cmd.OutOrStdout(), "TARGET\tdir\t%s\t.\n", plan.TargetRoot)
+		fmt.Fprintf(cmd.OutOrStdout(), "CHECKSUM\ttemplate\t%s\t.\n", plan.Checksum)
+		for _, file := range plan.Files {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\tfile\t%s\t.\n", file.Action, file.Path)
+		}
+		if !plan.WouldWrite {
+			fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tok\t.\tno changes")
+			return
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tdry_run\t.\tno changes written")
+		return
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Template sync plan")
+	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", plan.ProjectRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Source: %s\n", plan.SourceRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Target: %s\n", plan.TargetRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Checksum: %s\n", plan.Checksum)
+	if options.TemplatePath != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Template path override: %s\n", options.TemplatePath)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Mode: dry-run")
+
+	fmt.Fprintln(cmd.OutOrStdout(), "\nFiles")
+	for _, file := range plan.Files {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", file.Action, file.Path)
+	}
+	if len(plan.Files) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no file changes")
+	}
+
+	if !plan.WouldWrite {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: no changes")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nResult: dry run, no changes written")
 }
 
 func newValidateCommand() *cobra.Command {

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -58,6 +58,20 @@ project new my-app --global-tmp
 project init [project-directory]
 ```
 
+If `[project-directory]` is omitted, the CLI uses the current directory.
+
+## Sync Template Snapshot
+
+```sh
+project template sync
+project template sync --dry-run
+project template sync --dry-run --format tsv
+```
+
+The project path is optional and defaults to the current directory.
+
+`--template-path` is only needed when testing against a local template checkout instead of the template source recorded in the project lock.
+
 ## Modules
 
 ```sh

--- a/internal/projectvalidator/sync.go
+++ b/internal/projectvalidator/sync.go
@@ -1,24 +1,69 @@
 package projectvalidator
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 type TemplateSyncOptions struct {
 	TemplatePath string
+	DryRun       bool
+}
+
+type TemplateSyncPlan struct {
+	ProjectRoot string
+	SourceRoot  string
+	TargetRoot  string
+	Checksum    string
+	Files       []TemplateSyncFile
+	WouldWrite  bool
+}
+
+type TemplateSyncFile struct {
+	Action string
+	Path   string
 }
 
 func SyncTemplate(projectRoot string, options TemplateSyncOptions) (string, string, error) {
-	root, err := filepath.Abs(projectRoot)
+	plan, err := PlanTemplateSync(projectRoot, options)
 	if err != nil {
 		return "", "", err
 	}
-	lock, err := readTemplateLock(root)
+	if options.DryRun {
+		return plan.TargetRoot, plan.Checksum, nil
+	}
+	if err := os.RemoveAll(plan.TargetRoot); err != nil {
+		return "", "", err
+	}
+	if err := copyDirectory(plan.SourceRoot, plan.TargetRoot); err != nil {
+		return "", "", err
+	}
+	lock, err := readTemplateLock(plan.ProjectRoot)
 	if err != nil {
 		return "", "", err
+	}
+	if options.TemplatePath != "" {
+		lock.TemplatePath = options.TemplatePath
+	}
+	lock.Checksum = plan.Checksum
+	if _, err := writeTemplateLock(plan.ProjectRoot, lock); err != nil {
+		return "", "", err
+	}
+	return plan.TargetRoot, plan.Checksum, nil
+}
+
+func PlanTemplateSync(projectRoot string, options TemplateSyncOptions) (TemplateSyncPlan, error) {
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return TemplateSyncPlan{}, err
+	}
+	lock, err := readTemplateLock(root)
+	if err != nil {
+		return TemplateSyncPlan{}, err
 	}
 	sourceLock := lock
 	if options.TemplatePath != "" {
@@ -26,27 +71,25 @@ func SyncTemplate(projectRoot string, options TemplateSyncOptions) (string, stri
 	}
 	sourceRoot, err := resolveTemplateSourceRoot(root, sourceLock)
 	if err != nil {
-		return "", "", err
+		return TemplateSyncPlan{}, err
 	}
 	targetRoot := filepath.Join(root, ".project", "template")
-	if err := os.RemoveAll(targetRoot); err != nil {
-		return "", "", err
-	}
-	if err := copyDirectory(sourceRoot, targetRoot); err != nil {
-		return "", "", err
-	}
-	checksum, err := checksumTemplateRoot(targetRoot)
+	checksum, err := checksumTemplateRoot(sourceRoot)
 	if err != nil {
-		return "", "", err
+		return TemplateSyncPlan{}, err
 	}
-	lock.Checksum = checksum
-	if options.TemplatePath != "" {
-		lock.TemplatePath = options.TemplatePath
+	files, err := planTemplateSyncFiles(sourceRoot, targetRoot)
+	if err != nil {
+		return TemplateSyncPlan{}, err
 	}
-	if _, err := writeTemplateLock(root, lock); err != nil {
-		return "", "", err
-	}
-	return targetRoot, checksum, nil
+	return TemplateSyncPlan{
+		ProjectRoot: root,
+		SourceRoot:  sourceRoot,
+		TargetRoot:  targetRoot,
+		Checksum:    checksum,
+		Files:       files,
+		WouldWrite:  len(files) > 0 || lock.Checksum != checksum || options.TemplatePath != "",
+	}, nil
 }
 
 func resolveTemplateSourceRoot(projectRoot string, lock TemplateLock) (string, error) {
@@ -113,4 +156,85 @@ func copyFile(source string, target string) error {
 	defer output.Close()
 	_, err = io.Copy(output, input)
 	return err
+}
+
+func planTemplateSyncFiles(sourceRoot string, targetRoot string) ([]TemplateSyncFile, error) {
+	sourceFiles, err := collectTemplateSyncFiles(sourceRoot)
+	if err != nil {
+		return nil, err
+	}
+	targetFiles, err := collectTemplateSyncFiles(targetRoot)
+	if err != nil {
+		return nil, err
+	}
+	paths := map[string]bool{}
+	for path := range sourceFiles {
+		paths[path] = true
+	}
+	for path := range targetFiles {
+		paths[path] = true
+	}
+	sortedPaths := make([]string, 0, len(paths))
+	for path := range paths {
+		sortedPaths = append(sortedPaths, path)
+	}
+	sort.Strings(sortedPaths)
+
+	plan := []TemplateSyncFile{}
+	for _, path := range sortedPaths {
+		sourcePath, inSource := sourceFiles[path]
+		targetPath, inTarget := targetFiles[path]
+		switch {
+		case inSource && !inTarget:
+			plan = append(plan, TemplateSyncFile{Action: "ADD", Path: path})
+		case !inSource && inTarget:
+			plan = append(plan, TemplateSyncFile{Action: "DELETE", Path: path})
+		default:
+			equal, err := filesEqual(sourcePath, targetPath)
+			if err != nil {
+				return nil, err
+			}
+			if !equal {
+				plan = append(plan, TemplateSyncFile{Action: "UPDATE", Path: path})
+			}
+		}
+	}
+	return plan, nil
+}
+
+func collectTemplateSyncFiles(root string) (map[string]string, error) {
+	files := map[string]string{}
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return files, nil
+	}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files[normalizePath(relative)] = path
+		return nil
+	})
+	return files, err
+}
+
+func filesEqual(left string, right string) (bool, error) {
+	leftBody, err := os.ReadFile(left)
+	if err != nil {
+		return false, err
+	}
+	rightBody, err := os.ReadFile(right)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(leftBody, rightBody), nil
 }


### PR DESCRIPTION
## Summary\n- add --dry-run support to project template sync\n- keep project-directory optional with current directory as default\n- add TSV output for template sync plans\n- document that --template-path is only a local override\n\n## Validation\n- go test ./...\n- bun run check\n- go run ./cmd/project template sync --dry-run --format tsv