### PR TITLE
Show module origin in validation output

### DIFF
--- a/internal/projectvalidator/modules.go
+++ b/internal/projectvalidator/modules.go
@@ -335,6 +335,27 @@ type ownRule struct {
 	match func(string) bool
 }
 
+func moduleForPath(template TemplateSpec, path string) string {
+	names := make([]string, 0, len(template.Modules))
+	for name := range template.Modules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, moduleName := range names {
+		module := template.Modules[moduleName]
+		for _, pattern := range module.Owns {
+			regex, err := compilePathPattern(pattern, nil)
+			if err != nil {
+				continue
+			}
+			if regex.MatchString(path) {
+				return moduleName
+			}
+		}
+	}
+	return ""
+}
+
 func formatModuleConflicts(conflicts []ModuleInstallConflict) string {
 	parts := make([]string, 0, len(conflicts))
 	for _, conflict := range conflicts {

--- a/internal/projectvalidator/output.go
+++ b/internal/projectvalidator/output.go
@@ -72,7 +72,7 @@ func PrintFileReportWithOptions(report FileValidation, options OutputOptions) {
 	}
 	fmt.Println(report.Path)
 	fmt.Println()
-	printStatusLine(report.Path, report.Status, report.Note, options)
+	printStatusLine(report.Path, report.Status, fileModuleDetail(report), options)
 	for _, diagnostic := range report.Diagnostics {
 		printStatusLine(diagnostic.Path, diagnostic.Status, diagnostic.Note, options)
 	}
@@ -86,7 +86,7 @@ func PrintFileReportWithOptions(report FileValidation, options OutputOptions) {
 
 func printTable(report Report, options OutputOptions) {
 	for _, file := range report.Files {
-		printStatusLine(file.Path, file.Status, file.Note, options)
+		printStatusLine(file.Path, file.Status, fileModuleDetail(file), options)
 		for _, diagnostic := range file.Diagnostics {
 			if diagnostic.Status == StatusViolation {
 				printStatusLine("  "+diagnostic.Path, diagnostic.Status, diagnostic.Note, options)
@@ -96,9 +96,9 @@ func printTable(report Report, options OutputOptions) {
 }
 
 func printProjectTSV(report Report) {
-	fmt.Println("status\tkind\tpath\tcode\tdetail")
+	fmt.Println("status\tkind\tpath\tcode\tmodule")
 	for _, entry := range report.Structure {
-		fmt.Printf("%s\t%s\t%s\t%s\t%s\n", entry.Status, entry.Kind, entry.Path, entry.Code, entry.Note)
+		fmt.Printf("%s\t%s\t%s\t%s\t%s\n", entry.Status, entry.Kind, entry.Path, entry.Code, structureModuleDetail(entry))
 	}
 	if report.OK {
 		fmt.Println("RESULT\tresult\t.\tok\tproject adheres to template")
@@ -108,8 +108,8 @@ func printProjectTSV(report Report) {
 }
 
 func printFileTSV(report FileValidation) {
-	fmt.Println("status\tkind\tpath\tcode\tdetail")
-	fmt.Printf("%s\tfile\t%s\t%s\t%s\n", report.Status, report.Path, report.Code, report.Note)
+	fmt.Println("status\tkind\tpath\tcode\tmodule")
+	fmt.Printf("%s\tfile\t%s\t%s\t%s\n", report.Status, report.Path, report.Code, fileModuleDetail(report))
 	for _, diagnostic := range report.Diagnostics {
 		fmt.Printf("%s\tdiagnostic\t%s\t%s\t%s\n", diagnostic.Status, diagnostic.Path, diagnostic.Status, diagnostic.Note)
 	}
@@ -169,9 +169,29 @@ func printTreeChildren(node *treeNode, prefix string, options OutputOptions) {
 		if entry.Kind == "dir" {
 			label += "/"
 		}
-		printStatusLine(prefix+branch+label, entry.Status, entry.Note, options)
+		printStatusLine(prefix+branch+label, entry.Status, structureModuleDetail(*entry), options)
 		printTreeChildren(child, nextPrefix, options)
 	}
+}
+
+func structureModuleDetail(entry StructureEntry) string {
+	if entry.Module != "" {
+		return entry.Module
+	}
+	if entry.Code == "template" || entry.Code == "missing" {
+		return "template"
+	}
+	return "-"
+}
+
+func fileModuleDetail(file FileValidation) string {
+	if file.Module != "" {
+		return file.Module
+	}
+	if file.Code == "template" || file.Code == "missing" {
+		return "template"
+	}
+	return "-"
 }
 
 func printStatusLine(label string, status Status, note string, options OutputOptions) {

--- a/internal/projectvalidator/structure.go
+++ b/internal/projectvalidator/structure.go
@@ -50,18 +50,20 @@ func validateStructure(projectRoot string, template TemplateSpec, files []FileVa
 	for fixedPath := range fixedPaths {
 		fileStatus, hasFileStatus := fileStatusByPath[fixedPath]
 		if !actualFiles[fixedPath] {
-			entries[fixedPath] = StructureEntry{Path: fixedPath, Kind: "file", Status: StatusMissing, Code: "missing", Note: "missing"}
+			entries[fixedPath] = StructureEntry{Path: fixedPath, Kind: "file", Status: StatusMissing, Code: "missing", Note: "missing", Module: moduleForPath(template, fixedPath)}
 			continue
 		}
 		status := StatusOK
 		code := "template"
 		note := "template"
+		module := moduleForPath(template, fixedPath)
 		if hasFileStatus {
 			status = fileStatus.Status
 			code = fileStatus.Code
 			note = fileStatus.Note
+			module = fileStatus.Module
 		}
-		entries[fixedPath] = StructureEntry{Path: fixedPath, Kind: "file", Status: status, Code: code, Note: note}
+		entries[fixedPath] = StructureEntry{Path: fixedPath, Kind: "file", Status: status, Code: code, Note: note, Module: module}
 	}
 
 	for actualFile := range actualFiles {
@@ -69,7 +71,7 @@ func validateStructure(projectRoot string, template TemplateSpec, files []FileVa
 			continue
 		}
 		if rule, ok := matchingSlot(slotRules, actualFile); ok {
-			entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusAdded, Code: "slot", Note: rule.placeholder, Slot: rule.placeholder}
+			entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusAdded, Code: "slot", Note: rule.placeholder, Slot: rule.placeholder, Module: moduleForPath(template, actualFile)}
 			continue
 		}
 		entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusViolation, Code: "not_allowed", Note: "not_allowed"}
@@ -95,18 +97,20 @@ func validateTreeStructure(projectRoot string, template TemplateSpec, files []Fi
 	for templateFile := range template.TemplateFiles {
 		fileStatus, hasFileStatus := fileStatusByPath[templateFile]
 		if !actualFiles[templateFile] {
-			entries[templateFile] = StructureEntry{Path: templateFile, Kind: "file", Status: StatusMissing, Code: "missing", Note: "missing"}
+			entries[templateFile] = StructureEntry{Path: templateFile, Kind: "file", Status: StatusMissing, Code: "missing", Note: "missing", Module: moduleForPath(template, templateFile)}
 			continue
 		}
 		status := StatusOK
 		code := "template"
 		note := "template"
+		module := moduleForPath(template, templateFile)
 		if hasFileStatus {
 			status = fileStatus.Status
 			code = fileStatus.Code
 			note = fileStatus.Note
+			module = fileStatus.Module
 		}
-		entries[templateFile] = StructureEntry{Path: templateFile, Kind: "file", Status: status, Code: code, Note: note}
+		entries[templateFile] = StructureEntry{Path: templateFile, Kind: "file", Status: status, Code: code, Note: note, Module: module}
 	}
 
 	for actualFile := range actualFiles {
@@ -114,7 +118,7 @@ func validateTreeStructure(projectRoot string, template TemplateSpec, files []Fi
 			continue
 		}
 		if slot, ok := matchingTreeSlot(template.Slots, actualFile); ok {
-			entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusAdded, Code: "slot", Note: slot.Name, Slot: slot.Name}
+			entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusAdded, Code: "slot", Note: slot.Name, Slot: slot.Name, Module: moduleForPath(template, actualFile)}
 			continue
 		}
 		entries[actualFile] = StructureEntry{Path: actualFile, Kind: "file", Status: StatusViolation, Code: "not_allowed", Note: "not_allowed"}
@@ -198,7 +202,7 @@ func addParentDirectories(entries map[string]StructureEntry) {
 				code = "slot"
 				note = entry.Slot
 			}
-			entries[dir] = StructureEntry{Path: dir, Kind: "dir", Status: StatusOK, Code: code, Note: note, Slot: entry.Slot}
+			entries[dir] = StructureEntry{Path: dir, Kind: "dir", Status: StatusOK, Code: code, Note: note, Slot: entry.Slot, Module: entry.Module}
 		}
 	}
 }

--- a/internal/projectvalidator/types.go
+++ b/internal/projectvalidator/types.go
@@ -106,6 +106,7 @@ type StructureEntry struct {
 	Code   string
 	Note   string
 	Slot   string
+	Module string
 }
 
 type FileDiagnostic struct {
@@ -119,6 +120,7 @@ type FileValidation struct {
 	Status      Status
 	Code        string
 	Note        string
+	Module      string
 	Diagnostics []FileDiagnostic
 }
 

--- a/internal/projectvalidator/validate.go
+++ b/internal/projectvalidator/validate.go
@@ -26,7 +26,9 @@ func ValidateProject(projectRoot string) (Report, error) {
 	}
 	files := []FileValidation{}
 	for _, fileSpec := range template.Files {
-		files = append(files, validateTemplateFile(root, template.Root, fileSpec, values))
+		file := validateTemplateFile(root, template.Root, fileSpec, values)
+		file.Module = moduleForPath(template, file.Path)
+		files = append(files, file)
 	}
 	structure := validateStructure(root, template, files)
 	files = mergeStructureOnlyFiles(files, structure)
@@ -77,12 +79,14 @@ func ValidateProjectFile(projectRoot string, filePath string) (FileValidation, e
 	if !ok {
 		if template.TreeMode {
 			if slot, ok := matchingTreeSlot(template.Slots, normalized); ok {
-				return FileValidation{Path: normalized, Status: StatusAdded, Code: "slot", Note: slot.Name}, nil
+				return FileValidation{Path: normalized, Status: StatusAdded, Code: "slot", Note: slot.Name, Module: moduleForPath(template, normalized)}, nil
 			}
 		}
 		return FileValidation{Path: normalized, Status: StatusViolation, Code: "not_allowed", Note: "not_allowed"}, nil
 	}
-	return validateTemplateFile(root, template.Root, fileSpec, values), nil
+	file := validateTemplateFile(root, template.Root, fileSpec, values)
+	file.Module = moduleForPath(template, file.Path)
+	return file, nil
 }
 
 func mergeStructureOnlyFiles(files []FileValidation, structure []StructureEntry) []FileValidation {
@@ -97,7 +101,7 @@ func mergeStructureOnlyFiles(files []FileValidation, structure []StructureEntry)
 		if _, ok := byPath[entry.Path]; ok {
 			continue
 		}
-		byPath[entry.Path] = FileValidation{Path: entry.Path, Status: entry.Status, Code: entry.Code, Note: entry.Note}
+		byPath[entry.Path] = FileValidation{Path: entry.Path, Status: entry.Status, Code: entry.Code, Note: entry.Note, Module: entry.Module}
 	}
 	result := make([]FileValidation, 0, len(byPath))
 	for _, file := range byPath {


### PR DESCRIPTION
## Summary\n- separate slot detail from module origin in validation results\n- print module as the right-hand validation column\n- show '-' when a file is project-owned or violating and no module can be inferred\n\n## Validation\n- go test ./...\n- bun run check\n- go run ./cmd/project validate --format tsv