### PR TITLE
Add validation quarantine mode

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -792,6 +792,9 @@ func printTemplateSyncPlan(cmd *cobra.Command, plan projectvalidator.TemplateSyn
 
 func newValidateCommand() *cobra.Command {
 	options := projectvalidator.DefaultOutputOptions()
+	quarantine := false
+	dryRun := false
+	yes := false
 	cmd := &cobra.Command{
 		Use:               "validate [project-directory|file]",
 		Short:             "Validate a project against its template",
@@ -802,17 +805,32 @@ func newValidateCommand() *cobra.Command {
 			if len(args) == 1 {
 				target = args[0]
 			}
+			if quarantine {
+				return validateAndQuarantine(cmd, target, options, projectvalidator.ViolationQuarantineOptions{Apply: yes, DryRun: dryRun})
+			}
 			return validate(target, options)
 		},
 	}
 	cmd.Flags().StringVar((*string)(&options.Format), "format", string(projectvalidator.OutputFormatPretty), "output format")
 	cmd.Flags().StringVar((*string)(&options.View), "view", string(projectvalidator.ViewModeTree), "pretty output view")
 	cmd.Flags().StringVar((*string)(&options.ColorScope), "color-scope", string(projectvalidator.ColorScopeLine), "color scope")
+	cmd.Flags().BoolVar(&quarantine, "quarantine", false, "move not_allowed validation violations into .project/quarantine")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the quarantine plan without writing changes")
 	cmd.Flags().Bool("status-color-only", false, "color only the status text")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply the quarantine plan without prompting")
 	must(cmd.RegisterFlagCompletionFunc("format", fixedValuesCompletion("pretty", "tsv")))
 	must(cmd.RegisterFlagCompletionFunc("view", fixedValuesCompletion("tree", "table")))
 	must(cmd.RegisterFlagCompletionFunc("color-scope", fixedValuesCompletion("line", "status")))
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if yes && dryRun {
+			return fmt.Errorf("--yes and --dry-run cannot be used together")
+		}
+		if !quarantine && (yes || dryRun) {
+			return fmt.Errorf("--yes and --dry-run require --quarantine")
+		}
+		if quarantine && options.Format == projectvalidator.OutputFormatTSV && !dryRun && !yes {
+			return fmt.Errorf("use --dry-run or --yes with --quarantine --format tsv")
+		}
 		statusOnly, err := cmd.Flags().GetBool("status-color-only")
 		if err != nil {
 			return err
@@ -823,6 +841,136 @@ func newValidateCommand() *cobra.Command {
 		return validateOutputOptions(options)
 	}
 	return cmd
+}
+
+func validateAndQuarantine(cmd *cobra.Command, target string, options projectvalidator.OutputOptions, quarantineOptions projectvalidator.ViolationQuarantineOptions) error {
+	projectRoot, err := resolveProjectDirectoryTarget(target)
+	if err != nil {
+		return err
+	}
+	report, err := projectvalidator.ValidateProject(projectRoot)
+	if err != nil {
+		return err
+	}
+	plan := projectvalidator.PlanViolationQuarantine(report)
+	printViolationQuarantinePlan(cmd, plan, quarantineOptions, options.Format)
+	if quarantineOptions.DryRun || len(plan.Files) == 0 {
+		return nil
+	}
+	if !quarantineOptions.Apply {
+		confirmed, err := confirmApply(cmd)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			printQuarantineCanceled(cmd, options.Format)
+			return nil
+		}
+	}
+	applied, err := projectvalidator.ApplyViolationQuarantine(plan)
+	if err != nil {
+		return err
+	}
+	printQuarantineApplied(cmd, applied, options.Format)
+	return nil
+}
+
+func resolveProjectDirectoryTarget(target string) (string, error) {
+	if target == "" {
+		return filepath.Abs(".")
+	}
+	resolved, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	stat, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !stat.IsDir() {
+		return "", fmt.Errorf("--quarantine only supports project directories")
+	}
+	return resolved, nil
+}
+
+func printViolationQuarantinePlan(cmd *cobra.Command, plan projectvalidator.ViolationQuarantinePlan, options projectvalidator.ViolationQuarantineOptions, format projectvalidator.OutputFormat) {
+	if format == projectvalidator.OutputFormatTSV {
+		mode := "confirm"
+		if options.DryRun {
+			mode = "dry_run"
+		} else if options.Apply {
+			mode = "apply"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "PLAN\tviolation_quarantine\t%s\t%s\n", mode, plan.ProjectRoot)
+		fmt.Fprintf(cmd.OutOrStdout(), "TARGET\tdir\t%s\t.\n", plan.QuarantineRoot)
+		for _, file := range plan.Files {
+			module := file.Module
+			if module == "" {
+				module = "-"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\tfile\t%s\t%s\t%s\t%s\n", file.Action, file.OriginalPath, file.QuarantinePath, file.Code, module)
+		}
+		if len(plan.Files) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tok\t.\tno quarantinable violations")
+			return
+		}
+		if options.DryRun {
+			fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tdry_run\t.\tno changes written")
+			return
+		}
+		if options.Apply {
+			fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tapply\t.\tapplying")
+			return
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tconfirm\t.\twaiting for confirmation")
+		return
+	}
+
+	mode := "confirm"
+	if options.DryRun {
+		mode = "dry-run"
+	} else if options.Apply {
+		mode = "apply"
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Violation quarantine plan")
+	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", plan.ProjectRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Target: %s\n", plan.QuarantineRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Mode: %s\n\n", mode)
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Files")
+	for _, file := range plan.Files {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s %s -> %s\n", file.Action, file.OriginalPath, file.QuarantinePath)
+	}
+	if len(plan.Files) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no quarantinable violations")
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: no changes")
+		return
+	}
+	if options.DryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: dry run, no changes written")
+		return
+	}
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: applying")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nResult: waiting for confirmation")
+}
+
+func printQuarantineApplied(cmd *cobra.Command, plan projectvalidator.ViolationQuarantinePlan, format projectvalidator.OutputFormat) {
+	if format == projectvalidator.OutputFormatTSV {
+		fmt.Fprintf(cmd.OutOrStdout(), "RESULT\tapplied\t%s\tmanifest written\n", plan.ManifestPath)
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Result: applied\nManifest: %s\n", plan.ManifestPath)
+}
+
+func printQuarantineCanceled(cmd *cobra.Command, format projectvalidator.OutputFormat) {
+	if format == projectvalidator.OutputFormatTSV {
+		fmt.Fprintln(cmd.OutOrStdout(), "RESULT\tcanceled\t.\tno changes written")
+		return
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Result: canceled, no changes written")
 }
 
 func validate(target string, options projectvalidator.OutputOptions) error {

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -100,4 +100,10 @@ Use `-y` or `--yes` to apply without prompting.
 ```sh
 project validate [project-directory]
 project validate [project-directory] --format tsv
+project validate --quarantine --dry-run
+project validate --quarantine --yes
 ```
+
+`--quarantine` moves `not_allowed` file violations into `.project/quarantine/<original-path>`.
+
+The quarantine directory is ignored by template validation but is not ignored by Git, so quarantined files can be reviewed and committed.

--- a/internal/projectvalidator/quarantine.go
+++ b/internal/projectvalidator/quarantine.go
@@ -1,0 +1,81 @@
+package projectvalidator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func PlanViolationQuarantine(report Report) ViolationQuarantinePlan {
+	quarantineRoot := filepath.Join(report.ProjectRoot, ".project", "quarantine")
+	plan := ViolationQuarantinePlan{
+		ProjectRoot:    report.ProjectRoot,
+		QuarantineRoot: quarantineRoot,
+		ManifestPath:   filepath.Join(quarantineRoot, "manifest.tsv"),
+	}
+	seen := map[string]bool{}
+	for _, entry := range report.Structure {
+		if entry.Kind != "file" || entry.Status != StatusViolation || entry.Code != "not_allowed" {
+			continue
+		}
+		if seen[entry.Path] {
+			continue
+		}
+		seen[entry.Path] = true
+		quarantinePath := filepath.ToSlash(filepath.Join(".project", "quarantine", filepath.FromSlash(entry.Path)))
+		plan.Files = append(plan.Files, ViolationQuarantineFile{
+			Action:         "MOVE",
+			OriginalPath:   entry.Path,
+			QuarantinePath: quarantinePath,
+			Code:           entry.Code,
+			Module:         entry.Module,
+		})
+	}
+	plan.WouldWrite = len(plan.Files) > 0
+	return plan
+}
+
+func ApplyViolationQuarantine(plan ViolationQuarantinePlan) (ViolationQuarantinePlan, error) {
+	if len(plan.Files) == 0 {
+		return plan, nil
+	}
+	for _, file := range plan.Files {
+		sourcePath := filepath.Join(plan.ProjectRoot, filepath.FromSlash(file.OriginalPath))
+		targetPath := filepath.Join(plan.ProjectRoot, filepath.FromSlash(file.QuarantinePath))
+		if _, err := os.Stat(sourcePath); err != nil {
+			return plan, fmt.Errorf("quarantine source %s: %w", file.OriginalPath, err)
+		}
+		if _, err := os.Stat(targetPath); err == nil {
+			return plan, fmt.Errorf("quarantine target already exists: %s", file.QuarantinePath)
+		} else if !os.IsNotExist(err) {
+			return plan, err
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return plan, err
+		}
+		if err := os.Rename(sourcePath, targetPath); err != nil {
+			return plan, fmt.Errorf("move %s to quarantine: %w", file.OriginalPath, err)
+		}
+		removeEmptyParents(plan.ProjectRoot, filepath.Dir(sourcePath))
+	}
+	if err := writeViolationQuarantineManifest(plan); err != nil {
+		return plan, err
+	}
+	return plan, nil
+}
+
+func writeViolationQuarantineManifest(plan ViolationQuarantinePlan) error {
+	if err := os.MkdirAll(filepath.Dir(plan.ManifestPath), 0o755); err != nil {
+		return err
+	}
+	lines := []string{"action\toriginal_path\tquarantine_path\tcode\tmodule"}
+	for _, file := range plan.Files {
+		module := file.Module
+		if module == "" {
+			module = "-"
+		}
+		lines = append(lines, strings.Join([]string{file.Action, file.OriginalPath, file.QuarantinePath, file.Code, module}, "\t"))
+	}
+	return os.WriteFile(plan.ManifestPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+}

--- a/internal/projectvalidator/types.go
+++ b/internal/projectvalidator/types.go
@@ -132,3 +132,24 @@ type Report struct {
 	Files         []FileValidation
 	OK            bool
 }
+
+type ViolationQuarantineOptions struct {
+	Apply  bool
+	DryRun bool
+}
+
+type ViolationQuarantinePlan struct {
+	ProjectRoot    string
+	QuarantineRoot string
+	Files          []ViolationQuarantineFile
+	WouldWrite     bool
+	ManifestPath   string
+}
+
+type ViolationQuarantineFile struct {
+	Action         string
+	OriginalPath   string
+	QuarantinePath string
+	Code           string
+	Module         string
+}


### PR DESCRIPTION
## Summary\n- add project validate --quarantine\n- move not_allowed file violations into .project/quarantine/<original-path>\n- write a Git-visible quarantine manifest\n- support dry-run, yes, and TSV output\n\n## Validation\n- go test ./...\n- bun run check\n- go run ./cmd/project validate --quarantine --dry-run --format tsv\n- applied quarantine mode against a temporary project copy