### PR TITLE
Preserve GitHub Actions expressions in templates

### DIFF
--- a/internal/projectvalidator/values.go
+++ b/internal/projectvalidator/values.go
@@ -26,22 +26,34 @@ func readTemplateValues(projectRoot string) (TemplateValues, error) {
 }
 
 func renderTemplateValues(body []byte, values TemplateValues) ([]byte, error) {
-	rendered := placeholderRE.ReplaceAllStringFunc(string(body), func(match string) string {
-		name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(match, "{{"), "}}"))
+	source := string(body)
+	rendered := strings.Builder{}
+	cursor := 0
+	matches := placeholderRE.FindAllStringSubmatchIndex(source, -1)
+	for _, match := range matches {
+		if match[0] > 0 && source[match[0]-1] == '$' {
+			continue
+		}
+		rendered.WriteString(source[cursor:match[0]])
+		name := strings.TrimSpace(source[match[2]:match[3]])
 		value, ok := lookupTemplateValue(values, name)
 		if !ok {
-			return "\x00missing:" + name + "\x00"
+			rendered.WriteString("\x00missing:" + name + "\x00")
+		} else {
+			rendered.WriteString(value)
 		}
-		return value
-	})
-	if start := strings.Index(rendered, "\x00missing:"); start >= 0 {
-		rest := rendered[start+len("\x00missing:"):]
+		cursor = match[1]
+	}
+	rendered.WriteString(source[cursor:])
+	output := rendered.String()
+	if start := strings.Index(output, "\x00missing:"); start >= 0 {
+		rest := output[start+len("\x00missing:"):]
 		end := strings.Index(rest, "\x00")
 		if end >= 0 {
 			return nil, fmt.Errorf("missing template value %q", rest[:end])
 		}
 	}
-	return []byte(rendered), nil
+	return []byte(output), nil
 }
 
 func lookupTemplateValue(values TemplateValues, name string) (string, bool) {

--- a/internal/projectvalidator/values_test.go
+++ b/internal/projectvalidator/values_test.go
@@ -1,0 +1,34 @@
+package projectvalidator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTemplateValuesPreservesGitHubActionsExpressions(t *testing.T) {
+	body := []byte("token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}\nname: {{ project.slug }}\n")
+	values := TemplateValues{"project": map[string]any{"slug": "demo"}}
+
+	rendered, err := renderTemplateValues(body, values)
+	if err != nil {
+		t.Fatalf("renderTemplateValues returned error: %v", err)
+	}
+
+	got := string(rendered)
+	if !strings.Contains(got, "token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}") {
+		t.Fatalf("GitHub Actions expression was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "name: demo") {
+		t.Fatalf("project placeholder was not rendered:\n%s", got)
+	}
+}
+
+func TestRenderTemplateValuesReportsMissingProjectValues(t *testing.T) {
+	_, err := renderTemplateValues([]byte("name: {{ project.slug }}\n"), TemplateValues{})
+	if err == nil {
+		t.Fatal("expected missing template value error")
+	}
+	if !strings.Contains(err.Error(), `missing template value "project.slug"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve GitHub Actions expressions like `${{ secrets.NAME }}` during template rendering
- add renderer tests for GitHub Actions expressions and missing project values

## Verification
- go test ./internal/projectvalidator ./cmd/project
- generated a project from project-template with local project CLI
- project validate --format tsv
- bun install --frozen-lockfile
- bun run secrets:doctor
- CI=true bun run secrets:doctor fails with the expected missing-token setup message
- bun run check
- bun run build