### PR TITLE
Add GitHub setup to project create

### DIFF
--- a/cmd/project/github.go
+++ b/cmd/project/github.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const projectServiceAccountTokenRef = "op://projects/yiw7onwcvruugyi2ji6c4crwpy/password"
+
+type createGitHubRepositoryOptions struct {
+	Secrets bool
+}
+
+type createGitHubRepositoryResult struct {
+	URL       string
+	SecretSet bool
+}
+
+func createGitHubRepository(projectRoot string, options createGitHubRepositoryOptions) (createGitHubRepositoryResult, error) {
+	repoName, err := githubRepositoryName(projectRoot)
+	if err != nil {
+		return createGitHubRepositoryResult{}, err
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return createGitHubRepositoryResult{}, errors.New("gh is required for --github")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return createGitHubRepositoryResult{}, errors.New("git is required for --github")
+	}
+	if options.Secrets {
+		if _, err := exec.LookPath("op"); err != nil {
+			return createGitHubRepositoryResult{}, errors.New("op is required for --secrets")
+		}
+	}
+
+	output, err := runCommand("", nil, "gh", "repo", "create", repoName, "--private")
+	if err != nil {
+		return createGitHubRepositoryResult{}, fmt.Errorf("create GitHub repository: %w", err)
+	}
+	repoURL := firstNonEmptyLine(output)
+	if repoURL == "" {
+		repoURL, err = repositoryURL(repoName)
+		if err != nil {
+			return createGitHubRepositoryResult{}, err
+		}
+	}
+	repoRef, err := githubRepositoryRef(repoURL)
+	if err != nil {
+		return createGitHubRepositoryResult{}, err
+	}
+
+	secretSet := false
+	if options.Secrets {
+		token, err := readProjectServiceAccountToken()
+		if err != nil {
+			return createGitHubRepositoryResult{}, err
+		}
+		if err := setGitHubSecret(repoRef, token); err != nil {
+			return createGitHubRepositoryResult{}, err
+		}
+		secretSet = true
+	}
+
+	if err := initializeAndPushRepository(projectRoot, repoURL); err != nil {
+		return createGitHubRepositoryResult{}, err
+	}
+	return createGitHubRepositoryResult{URL: repoURL, SecretSet: secretSet}, nil
+}
+
+func githubRepositoryName(projectRoot string) (string, error) {
+	name := filepath.Base(filepath.Clean(projectRoot))
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		return "", fmt.Errorf("cannot derive GitHub repository name from %q", projectRoot)
+	}
+	return name, nil
+}
+
+func repositoryURL(repoName string) (string, error) {
+	output, err := runCommand("", nil, "gh", "repo", "view", repoName, "--json", "url", "--jq", ".url")
+	if err != nil {
+		return "", fmt.Errorf("read GitHub repository URL: %w", err)
+	}
+	repoURL := firstNonEmptyLine(output)
+	if repoURL == "" {
+		return "", errors.New("GitHub repository URL was empty")
+	}
+	return repoURL, nil
+}
+
+func readProjectServiceAccountToken() (string, error) {
+	output, err := runCommand("", nil, "op", "read", projectServiceAccountTokenRef)
+	if err != nil {
+		return "", fmt.Errorf("read OP_SERVICE_ACCOUNT_TOKEN from 1Password: %w", err)
+	}
+	token := strings.TrimRight(output, "\r\n")
+	if token == "" {
+		return "", errors.New("OP_SERVICE_ACCOUNT_TOKEN from 1Password was empty")
+	}
+	return token, nil
+}
+
+func setGitHubSecret(repoRef string, token string) error {
+	if _, err := runCommand("", []byte(token), "gh", "secret", "set", "OP_SERVICE_ACCOUNT_TOKEN", "--repo", repoRef); err != nil {
+		return fmt.Errorf("set GitHub secret OP_SERVICE_ACCOUNT_TOKEN: %w", err)
+	}
+	return nil
+}
+
+func initializeAndPushRepository(projectRoot string, repoURL string) error {
+	commands := [][]string{
+		{"git", "init"},
+		{"git", "branch", "-M", "main"},
+		{"git", "add", "-A"},
+		{"git", "commit", "-m", "Initial project"},
+		{"git", "remote", "add", "origin", repoURL},
+		{"git", "push", "-u", "origin", "main"},
+	}
+	for _, command := range commands {
+		if _, err := runCommand(projectRoot, nil, command[0], command[1:]...); err != nil {
+			return fmt.Errorf("%s: %w", strings.Join(command, " "), err)
+		}
+	}
+	return nil
+}
+
+func githubRepositoryRef(repoURL string) (string, error) {
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("parse GitHub repository URL: %w", err)
+	}
+	if parsed.Host != "github.com" {
+		return "", fmt.Errorf("unsupported GitHub repository URL %q", repoURL)
+	}
+	path := strings.Trim(strings.TrimSuffix(parsed.Path, ".git"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("unsupported GitHub repository URL %q", repoURL)
+	}
+	return parts[0] + "/" + parts[1], nil
+}
+
+func firstNonEmptyLine(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func runCommand(dir string, stdin []byte, name string, args ...string) (string, error) {
+	command := exec.Command(name, args...)
+	command.Dir = dir
+	if stdin != nil {
+		command.Stdin = bytes.NewReader(stdin)
+	}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return "", errors.New(message)
+	}
+	return string(output), nil
+}

--- a/cmd/project/github_test.go
+++ b/cmd/project/github_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestGitHubRepositoryRef(t *testing.T) {
+	tests := map[string]string{
+		"https://github.com/DotNaos/example":     "DotNaos/example",
+		"https://github.com/DotNaos/example.git": "DotNaos/example",
+	}
+	for input, want := range tests {
+		got, err := githubRepositoryRef(input)
+		if err != nil {
+			t.Fatalf("githubRepositoryRef(%q) returned error: %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("githubRepositoryRef(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestGitHubRepositoryRefRejectsUnsupportedURLs(t *testing.T) {
+	if _, err := githubRepositoryRef("https://example.com/DotNaos/example"); err == nil {
+		t.Fatal("expected unsupported host error")
+	}
+	if _, err := githubRepositoryRef("https://github.com/DotNaos"); err == nil {
+		t.Fatal("expected unsupported path error")
+	}
+}
+
+func TestGitHubRepositoryName(t *testing.T) {
+	got, err := githubRepositoryName("/tmp/my-app")
+	if err != nil {
+		t.Fatalf("githubRepositoryName returned error: %v", err)
+	}
+	if got != "my-app" {
+		t.Fatalf("githubRepositoryName = %q, want my-app", got)
+	}
+}

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -40,6 +40,8 @@ func newCreateCommand() *cobra.Command {
 	options := projectvalidator.InitOptions{}
 	localTmp := false
 	globalTmp := false
+	github := false
+	secrets := false
 	cmd := &cobra.Command{
 		Use:               "create [project-directory]",
 		Aliases:           []string{"new"},
@@ -47,6 +49,9 @@ func newCreateCommand() *cobra.Command {
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: directoryCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if secrets && !github {
+				return fmt.Errorf("--secrets requires --github")
+			}
 			if localTmp && globalTmp {
 				return fmt.Errorf("--local-tmp and --global-tmp cannot be used together")
 			}
@@ -92,11 +97,24 @@ func newCreateCommand() *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "Installed module: %s\n", plan.Module)
 				}
 			}
+			if github {
+				result, err := createGitHubRepository(resolved, createGitHubRepositoryOptions{Secrets: secrets})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "GitHub repository: %s\n", result.URL)
+				if result.SecretSet {
+					fmt.Fprintln(cmd.OutOrStdout(), "GitHub secret: OP_SERVICE_ACCOUNT_TOKEN set")
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), "Pushed initial commit: main")
+			}
 			fmt.Fprintf(cmd.OutOrStdout(), "cd %s\n", shellQuote(resolved))
 			return nil
 		},
 	}
 	addInitFlags(cmd, &options)
+	cmd.Flags().BoolVar(&github, "github", false, "create a private GitHub repository and push the project")
+	cmd.Flags().BoolVar(&secrets, "secrets", false, "set required GitHub secrets; requires --github")
 	cmd.Flags().BoolVar(&localTmp, "tmp", false, "create a local tmp project in ./tmp and install default modules")
 	cmd.Flags().BoolVar(&localTmp, "local-tmp", false, "create a local tmp project in ./tmp and install default modules")
 	cmd.Flags().BoolVar(&globalTmp, "global-tmp", false, "create a global tmp project in /tmp and install default modules")

--- a/cmd/project/main_test.go
+++ b/cmd/project/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCreateSecretsRequiresGitHub(t *testing.T) {
+	cmd := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"create", "my-app", "--secrets"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--secrets requires --github") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -18,6 +18,8 @@ Useful flags:
 --version <version>
 --commit <commit-or-label>
 --force
+--github
+--secrets
 --tmp
 --local-tmp
 --global-tmp
@@ -28,6 +30,10 @@ Useful flags:
 `--local-tmp` is the explicit form of `--tmp`.
 
 `--global-tmp` creates the generated project under `/tmp` with a random suffix.
+
+`--github` initializes Git, creates a private GitHub repository with the implicit `gh` owner, commits the project, and pushes `main`.
+
+`--secrets` is opt-in and requires `--github`. It sets `OP_SERVICE_ACCOUNT_TOKEN` on the new GitHub repository from the project 1Password vault before the first push.
 
 Example:
 


### PR DESCRIPTION
## Summary
- add `project create --github` to create a private GitHub repo and push `main`
- add opt-in `--secrets` to set `OP_SERVICE_ACCOUNT_TOKEN` before the first push
- document the new flags and add focused tests

## Verification
- go test ./...
- /tmp/project-local create project-cli-github-smoke --tmp --github --secrets --template DotNaos/project-template --template-path /Users/oli/projects/project-template --version local --commit <local>
- verified private repo DotNaos/project-cli-github-smoke-6a6a7154
- verified OP_SERVICE_ACCOUNT_TOKEN exists on the smoke repo
- watched smoke repo CI pass: check, secrets:doctor, build, and container