### PR TITLE
Add deploy config confirmation

### DIFF
--- a/cmd/project/deploy.go
+++ b/cmd/project/deploy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type deployOptions struct {
@@ -31,6 +33,19 @@ type deployProject struct {
 	Status     string
 }
 
+type deployConfig struct {
+	Host   string `yaml:"host"`
+	Path   string `yaml:"path"`
+	Branch string `yaml:"branch"`
+	Domain string `yaml:"domain"`
+	Email  string `yaml:"email"`
+}
+
+type deployCandidate struct {
+	Value  string
+	Source string
+}
+
 func newDeployCommand() *cobra.Command {
 	options := deployOptions{}
 	cmd := &cobra.Command{
@@ -47,7 +62,7 @@ func newDeployCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deployProjectToVPS(resolved, options)
+			result, err := deployProjectToVPS(cmd, resolved, options)
 			if err != nil {
 				return err
 			}
@@ -76,7 +91,7 @@ func newDeployStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := deployProjectStatus(resolved, options)
+			result, err := deployProjectStatus(cmd, resolved, options)
 			if err != nil {
 				return err
 			}
@@ -99,8 +114,8 @@ func addDeployFlags(cmd *cobra.Command, options *deployOptions) {
 	must(cmd.RegisterFlagCompletionFunc("path", directoryCompletion))
 }
 
-func deployProjectToVPS(projectRoot string, options deployOptions) (deployProject, error) {
-	project, options, err := resolveDeployProject(projectRoot, options, true)
+func deployProjectToVPS(cmd *cobra.Command, projectRoot string, options deployOptions) (deployProject, error) {
+	project, options, err := resolveDeployProject(cmd, projectRoot, options, true)
 	if err != nil {
 		return deployProject{}, err
 	}
@@ -117,8 +132,8 @@ func deployProjectToVPS(projectRoot string, options deployOptions) (deployProjec
 	return project, nil
 }
 
-func deployProjectStatus(projectRoot string, options deployOptions) (deployProject, error) {
-	project, options, err := resolveDeployProject(projectRoot, options, false)
+func deployProjectStatus(cmd *cobra.Command, projectRoot string, options deployOptions) (deployProject, error) {
+	project, options, err := resolveDeployProject(cmd, projectRoot, options, false)
 	if err != nil {
 		return deployProject{}, err
 	}
@@ -149,7 +164,7 @@ func deployProjectStatus(projectRoot string, options deployOptions) (deployProje
 	return project, nil
 }
 
-func resolveDeployProject(projectRoot string, options deployOptions, requireRuntimeValues bool) (deployProject, deployOptions, error) {
+func resolveDeployProject(cmd *cobra.Command, projectRoot string, options deployOptions, requireRuntimeValues bool) (deployProject, deployOptions, error) {
 	if _, err := os.Stat(filepath.Join(projectRoot, "deploy", "compose.yml")); err != nil {
 		return deployProject{}, options, fmt.Errorf("deploy/compose.yml is required: %w", err)
 	}
@@ -159,24 +174,11 @@ func resolveDeployProject(projectRoot string, options deployOptions, requireRunt
 	if _, err := os.Stat(filepath.Join(projectRoot, "deploy", "ingress.compose.yml")); err != nil {
 		return deployProject{}, options, fmt.Errorf("deploy/ingress.compose.yml is required: %w", err)
 	}
-	if options.Host == "" {
-		options.Host = firstEnv("PROJECT_DEPLOY_HOST", "DEPLOY_HOST")
+	config, err := readDeployConfig(projectRoot)
+	if err != nil {
+		return deployProject{}, options, err
 	}
-	if options.Host == "" {
-		options.Host = "os-vps"
-	}
-	if options.ProjectDomain == "" {
-		options.ProjectDomain = firstEnv("PROJECT_DOMAIN", "PROJECT_DEPLOY_DOMAIN")
-	}
-	if options.AcmeEmail == "" {
-		options.AcmeEmail = firstEnv("TRAEFIK_ACME_EMAIL", "PROJECT_DEPLOY_ACME_EMAIL")
-	}
-	if requireRuntimeValues && options.ProjectDomain == "" {
-		return deployProject{}, options, errors.New("PROJECT_DOMAIN is required; pass --domain or set PROJECT_DOMAIN")
-	}
-	if requireRuntimeValues && options.AcmeEmail == "" {
-		return deployProject{}, options, errors.New("TRAEFIK_ACME_EMAIL is required; pass --email or set TRAEFIK_ACME_EMAIL")
-	}
+	input := bufio.NewReader(cmd.InOrStdin())
 
 	remoteURL, err := gitRemoteURL(projectRoot)
 	if err != nil {
@@ -187,17 +189,47 @@ func resolveDeployProject(projectRoot string, options deployOptions, requireRunt
 		return deployProject{}, options, err
 	}
 	projectName := strings.TrimPrefix(repoRef[strings.LastIndex(repoRef, "/"):], "/")
-	if options.Branch == "" {
-		options.Branch, _ = gitCurrentBranch(projectRoot)
+	currentBranch, _ := gitCurrentBranch(projectRoot)
+	gitEmail, _ := gitConfigValue(projectRoot, "user.email")
+
+	options.Host, err = resolveDeployValue(cmd, input, "deploy host", "host", options.Host, []deployCandidate{
+		configCandidate(config.Host, "deploy/deploy.yaml"),
+		firstEnvCandidate("PROJECT_DEPLOY_HOST", "DEPLOY_HOST"),
+		{Value: "os-vps", Source: "standard SSH host"},
+	}, true)
+	if err != nil {
+		return deployProject{}, options, err
 	}
-	if options.Branch == "" {
-		options.Branch = "main"
+	options.RemotePath, err = resolveDeployValue(cmd, input, "remote path", "path", options.RemotePath, []deployCandidate{
+		configCandidate(config.Path, "deploy/deploy.yaml"),
+		firstEnvCandidate("PROJECT_DEPLOY_PATH", "DEPLOY_PATH"),
+		{Value: "/opt/projects/" + projectName, Source: "project name"},
+	}, true)
+	if err != nil {
+		return deployProject{}, options, err
 	}
-	if options.RemotePath == "" {
-		options.RemotePath = firstEnv("PROJECT_DEPLOY_PATH", "DEPLOY_PATH")
+	options.Branch, err = resolveDeployValue(cmd, input, "git branch", "branch", options.Branch, []deployCandidate{
+		configCandidate(config.Branch, "deploy/deploy.yaml"),
+		configCandidate(currentBranch, "current Git checkout"),
+		{Value: "main", Source: "standard branch"},
+	}, true)
+	if err != nil {
+		return deployProject{}, options, err
 	}
-	if options.RemotePath == "" {
-		options.RemotePath = "/opt/projects/" + projectName
+	options.ProjectDomain, err = resolveDeployValue(cmd, input, "project domain", "domain", options.ProjectDomain, []deployCandidate{
+		configCandidate(config.Domain, "deploy/deploy.yaml"),
+		firstEnvCandidate("PROJECT_DOMAIN", "PROJECT_DEPLOY_DOMAIN"),
+	}, requireRuntimeValues)
+	if err != nil {
+		return deployProject{}, options, err
+	}
+	options.AcmeEmail, err = resolveDeployValue(cmd, input, "ACME email", "email", options.AcmeEmail, []deployCandidate{
+		configCandidate(config.Email, "deploy/deploy.yaml"),
+		firstEnvCandidate("TRAEFIK_ACME_EMAIL", "PROJECT_DEPLOY_ACME_EMAIL"),
+		configCandidate(gitEmail, "Git config user.email"),
+	}, requireRuntimeValues)
+	if err != nil {
+		return deployProject{}, options, err
 	}
 
 	webURL := ""
@@ -215,6 +247,78 @@ func resolveDeployProject(projectRoot string, options deployOptions, requireRunt
 		WebURL:     webURL,
 		APIURL:     apiURL,
 	}, options, nil
+}
+
+func readDeployConfig(projectRoot string) (deployConfig, error) {
+	path := filepath.Join(projectRoot, "deploy", "deploy.yaml")
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return deployConfig{}, nil
+	}
+	if err != nil {
+		return deployConfig{}, fmt.Errorf("read deploy/deploy.yaml: %w", err)
+	}
+	config := deployConfig{}
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		return deployConfig{}, fmt.Errorf("parse deploy/deploy.yaml: %w", err)
+	}
+	return config, nil
+}
+
+func resolveDeployValue(cmd *cobra.Command, input *bufio.Reader, label string, flagName string, flagValue string, candidates []deployCandidate, required bool) (string, error) {
+	if cmd.Flags().Changed(flagName) {
+		if required && flagValue == "" {
+			return "", fmt.Errorf("%s is required; pass --%s", label, flagName)
+		}
+		return flagValue, nil
+	}
+	for _, candidate := range candidates {
+		value := strings.TrimSpace(candidate.Value)
+		if value == "" {
+			continue
+		}
+		accepted, err := confirmDeployCandidate(cmd, input, label, flagName, value, candidate.Source)
+		if err != nil {
+			return "", err
+		}
+		if accepted {
+			return value, nil
+		}
+		return "", fmt.Errorf("%s from %s was declined; rerun with --%s or update deploy/deploy.yaml", label, candidate.Source, flagName)
+	}
+	if required {
+		return "", fmt.Errorf("%s is required; pass --%s, set an environment variable, or add it to deploy/deploy.yaml", label, flagName)
+	}
+	return "", nil
+}
+
+func confirmDeployCandidate(cmd *cobra.Command, input *bufio.Reader, label string, flagName string, value string, source string) (bool, error) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Use %s from %s: %s? Y/n ", label, source, value)
+	answer, err := input.ReadString('\n')
+	if err != nil && answer == "" {
+		return false, fmt.Errorf("confirm %s: rerun with --%s or provide input", label, flagName)
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "", "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("confirm %s: answer y or n", label)
+	}
+}
+
+func configCandidate(value string, source string) deployCandidate {
+	return deployCandidate{Value: value, Source: source}
+}
+
+func firstEnvCandidate(names ...string) deployCandidate {
+	for _, name := range names {
+		if value := os.Getenv(name); value != "" {
+			return deployCandidate{Value: value, Source: "$" + name}
+		}
+	}
+	return deployCandidate{}
 }
 
 func deploySteps(project deployProject, options deployOptions) []string {
@@ -254,13 +358,12 @@ func gitCurrentBranch(projectRoot string) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-func firstEnv(names ...string) string {
-	for _, name := range names {
-		if value := os.Getenv(name); value != "" {
-			return value
-		}
+func gitConfigValue(projectRoot string, name string) (string, error) {
+	output, err := runCommand(projectRoot, nil, "git", "config", "--get", name)
+	if err != nil {
+		return "", err
 	}
-	return ""
+	return strings.TrimSpace(output), nil
 }
 
 func printDeployResult(cmd *cobra.Command, project deployProject, dryRun bool) {

--- a/cmd/project/deploy_test.go
+++ b/cmd/project/deploy_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestDeployStepsUseExistingComposeFiles(t *testing.T) {
@@ -31,4 +35,58 @@ func TestGitRemoteURLConvertsGitHubSSH(t *testing.T) {
 	if converted != "https://github.com/DotNaos/example" {
 		t.Fatalf("converted URL = %q", converted)
 	}
+}
+
+func TestResolveDeployValueUsesExplicitFlagWithoutPrompt(t *testing.T) {
+	cmd := deployValueTestCommand("flag-value", "")
+	must(cmd.Flags().Set("host", "flag-value"))
+
+	value, err := resolveDeployValue(cmd, bufio.NewReader(cmd.InOrStdin()), "deploy host", "host", "flag-value", []deployCandidate{
+		{Value: "config-value", Source: "deploy/deploy.yaml"},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "flag-value" {
+		t.Fatalf("value = %q", value)
+	}
+}
+
+func TestResolveDeployValueAcceptsDiscoveredValue(t *testing.T) {
+	cmd := deployValueTestCommand("", "\n")
+
+	value, err := resolveDeployValue(cmd, bufio.NewReader(cmd.InOrStdin()), "deploy host", "host", "", []deployCandidate{
+		{Value: "os-vps", Source: "deploy/deploy.yaml"},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "os-vps" {
+		t.Fatalf("value = %q", value)
+	}
+	if !strings.Contains(cmd.OutOrStdout().(*bytes.Buffer).String(), "Use deploy host from deploy/deploy.yaml: os-vps? Y/n") {
+		t.Fatalf("prompt missing:\n%s", cmd.OutOrStdout().(*bytes.Buffer).String())
+	}
+}
+
+func TestResolveDeployValueDeclinesDiscoveredValue(t *testing.T) {
+	cmd := deployValueTestCommand("", "n\n")
+
+	_, err := resolveDeployValue(cmd, bufio.NewReader(cmd.InOrStdin()), "deploy host", "host", "", []deployCandidate{
+		{Value: "os-vps", Source: "deploy/deploy.yaml"},
+	}, true)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "deploy host from deploy/deploy.yaml was declined") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func deployValueTestCommand(flagValue string, input string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("host", flagValue, "")
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&bytes.Buffer{})
+	return cmd
 }

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -79,13 +79,21 @@ project deploy status
 - `deploy/ingress.compose.yml` for the shared Traefik ingress.
 - `deploy/compose.yml` and `deploy/ingress.labels.yml` for this app.
 
-Defaults:
+Configuration can live in `deploy/deploy.yaml`:
 
-- `--host` defaults to `os-vps`.
-- `--path` defaults to `/opt/projects/<repo-name>`.
-- `--branch` defaults to the current branch, then `main`.
+```yaml
+host: os-vps
+path: /opt/projects/my-project
+branch: main
+domain: my-project.os-home.net
+email: you@example.com
+```
 
-`PROJECT_DOMAIN` and `TRAEFIK_ACME_EMAIL` can be set through flags or environment variables.
+Flags override config.
+
+If a value comes from `deploy/deploy.yaml`, an environment variable, Git config, or an inferred convention, the CLI asks before using it.
+
+Supported environment fallbacks are `PROJECT_DEPLOY_HOST`, `PROJECT_DEPLOY_PATH`, `PROJECT_DOMAIN`, `TRAEFIK_ACME_EMAIL`, and their older aliases.
 
 ## Sync Template Snapshot
 


### PR DESCRIPTION
## Summary
- read versioned deploy defaults from deploy/deploy.yaml
- ask before using config, env, Git, or inferred deploy values
- document the deploy config flow

## Verification
- go test ./...
- go build -o /tmp/project-local ./cmd/project
- generated tmp project from local project-template
- project deploy --dry-run accepts confirmed config values
- project deploy --dry-run fails when a config value is declined
- project deploy --dry-run with explicit flags skips prompts
- project validate --format tsv on generated tmp project