### PR TITLE
Add template smoke command

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -715,6 +715,7 @@ func newTemplateCommand() *cobra.Command {
 		Short: "Manage the local project template snapshot",
 	}
 	cmd.AddCommand(newTemplateSyncCommand())
+	cmd.AddCommand(newTemplateSmokeCommand())
 	return cmd
 }
 

--- a/cmd/project/template_smoke.go
+++ b/cmd/project/template_smoke.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/DotNaos/project-space/internal/projectvalidator"
+	"github.com/spf13/cobra"
+)
+
+type templateSmokeOptions struct {
+	Init              projectvalidator.InitOptions
+	Name              string
+	Container         bool
+	SkipChecks        bool
+	SkipSecretsDoctor bool
+	GlobalTmp         bool
+}
+
+func newTemplateSmokeCommand() *cobra.Command {
+	options := templateSmokeOptions{}
+	cmd := &cobra.Command{
+		Use:   "smoke",
+		Short: "Generate a tmp project and run template smoke checks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected arguments: %s", strings.Join(args, " "))
+			}
+			return runTemplateSmoke(cmd, options)
+		},
+	}
+	cmd.Flags().StringVar(&options.Init.Template, "template", "", "template repository")
+	cmd.Flags().StringVar(&options.Init.TemplatePath, "template-path", "", "template path")
+	cmd.Flags().StringVar(&options.Init.Version, "version", "", "template version")
+	cmd.Flags().StringVar(&options.Init.Commit, "commit", "", "template commit or label")
+	cmd.Flags().StringVar(&options.Name, "name", "generated-app", "tmp project name prefix")
+	cmd.Flags().BoolVar(&options.Container, "container", false, "build generated project containers")
+	cmd.Flags().BoolVar(&options.SkipChecks, "skip-checks", false, "skip dependency, secrets, check, and build commands")
+	cmd.Flags().BoolVar(&options.SkipSecretsDoctor, "skip-secrets-doctor", false, "skip bun run secrets:doctor")
+	cmd.Flags().BoolVar(&options.GlobalTmp, "global-tmp", false, "create the generated project under /tmp")
+	must(cmd.RegisterFlagCompletionFunc("template", fixedValuesCompletion("DotNaos/project-template")))
+	must(cmd.RegisterFlagCompletionFunc("template-path", directoryCompletion))
+	return cmd
+}
+
+func runTemplateSmoke(cmd *cobra.Command, options templateSmokeOptions) error {
+	target, err := tmpProjectTarget(options.Name, options.GlobalTmp)
+	if err != nil {
+		return err
+	}
+	resolved, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(resolved); err != nil {
+		return err
+	}
+
+	lockPath, err := projectvalidator.CreateProject(resolved, options.Init)
+	if err != nil {
+		return err
+	}
+	valuesPath, err := projectvalidator.WriteTmpTemplateValues(resolved)
+	if err != nil {
+		return err
+	}
+	plans, err := projectvalidator.InstallDefaultModules(resolved)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Generated project: %s\n", resolved)
+	fmt.Fprintf(cmd.OutOrStdout(), "Template lock: %s\n", lockPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Template values: %s\n", valuesPath)
+	for _, plan := range plans {
+		fmt.Fprintf(cmd.OutOrStdout(), "Installed module: %s\n", plan.Module)
+	}
+
+	if err := validateSmokeProject(resolved); err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "OK validate")
+
+	if !options.SkipChecks {
+		if err := runSmokeCommand(cmd, resolved, "bun", "install", "--frozen-lockfile"); err != nil {
+			return err
+		}
+		if !options.SkipSecretsDoctor {
+			if err := runSmokeCommand(cmd, resolved, "bun", "run", "secrets:doctor"); err != nil {
+				return err
+			}
+		}
+		if err := runSmokeCommand(cmd, resolved, "bun", "run", "check"); err != nil {
+			return err
+		}
+		if err := runSmokeCommand(cmd, resolved, "bun", "run", "build"); err != nil {
+			return err
+		}
+	}
+
+	if options.Container {
+		if err := runSmokeCommand(cmd, resolved, "bun", "run", "container:build"); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "RESULT ok %s\n", resolved)
+	return nil
+}
+
+func validateSmokeProject(projectRoot string) error {
+	report, err := projectvalidator.ValidateProject(projectRoot)
+	if err != nil {
+		return err
+	}
+	if !report.OK {
+		return errors.New("generated project does not adhere to template")
+	}
+	return nil
+}
+
+func runSmokeCommand(cmd *cobra.Command, dir string, name string, args ...string) error {
+	fmt.Fprintf(cmd.OutOrStdout(), "==> %s\n", strings.Join(append([]string{name}, args...), " "))
+	command := exec.Command(name, args...)
+	command.Dir = dir
+	command.Stdout = cmd.OutOrStdout()
+	command.Stderr = cmd.ErrOrStderr()
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("%s: %w", strings.Join(append([]string{name}, args...), " "), err)
+	}
+	return nil
+}

--- a/cmd/project/template_smoke_test.go
+++ b/cmd/project/template_smoke_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestValidateSmokeProjectFailsForInvalidProject(t *testing.T) {
+	root := t.TempDir()
+
+	err := validateSmokeProject(root)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -107,6 +107,19 @@ The project path is optional and defaults to the current directory.
 
 `--template-path` is only needed when testing against a local template checkout instead of the template source recorded in the project lock.
 
+## Smoke Test A Template
+
+```sh
+project template smoke --template-path <template-directory> --version local --commit local
+project template smoke --template-path <template-directory> --version local --commit local --skip-checks --container
+```
+
+This creates a generated tmp project, installs default modules, validates it, and runs the generated project's normal checks.
+
+Use `--container --skip-checks` for a focused generated-container smoke test.
+
+Use `--skip-secrets-doctor` for local smoke checks when no 1Password service token is available.
+
 ## Modules
 
 ```sh


### PR DESCRIPTION
## Summary
- add project template smoke for generated-project CI checks
- support container-only smoke checks with --container --skip-checks
- document the command

## Verification
- go test ./...
- go build -o /tmp/project-local ./cmd/project
- project template smoke --help
- project template smoke --template-path /Users/oli/projects/project-template --version local --commit local --skip-secrets-doctor
- project template smoke --template-path /Users/oli/projects/project-template --version local --commit local --skip-checks --container
- project template smoke --template-path /Users/oli/projects/project-template --version local --commit local --skip-checks