### PR TITLE
Add connector hub registry

### DIFF
--- a/Formula/project-space-connector.rb
+++ b/Formula/project-space-connector.rb
@@ -14,7 +14,10 @@ class ProjectSpaceConnector < Formula
 
   service do
     run [opt_bin/"project-space-connector"]
-    environment_variables PROJECT_SPACE_HOST: "127.0.0.1", PROJECT_SPACE_PORT: "4173"
+    environment_variables PROJECT_CONNECTOR_HUB_URL: "https://projects.os-home.net",
+      PROJECT_CONNECTOR_SERVICE_NAME: "project-space-connector",
+      PROJECT_SPACE_HOST: "127.0.0.1",
+      PROJECT_SPACE_PORT: "4173"
     keep_alive true
     log_path var/"log/project-space-connector.log"
     error_log_path var/"log/project-space-connector.log"

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile
+    environment:
+      PROJECT_CONNECTOR_SERVICE_NAME: project-space-web
     image: project-space-web:local
     restart: unless-stopped
 

--- a/docs/connector.md
+++ b/docs/connector.md
@@ -51,6 +51,8 @@ The connector reads these environment variables:
 ```bash
 PROJECT_SPACE_HOST=127.0.0.1
 PROJECT_SPACE_PORT=4173
+PROJECT_CONNECTOR_HUB_URL=https://projects.os-home.net
+PROJECT_CONNECTOR_SERVICE_NAME=project-space-connector
 PROJECT_SPACE_PRIVATE_VPS_BASE_URL=https://your-private-vps-platform-api
 PROJECT_SPACE_CONNECTOR_ORIGIN=https://your-machine.tailnet.ts.net
 ```
@@ -59,6 +61,8 @@ Defaults:
 
 - `PROJECT_SPACE_HOST` defaults to `127.0.0.1`.
 - `PROJECT_SPACE_PORT` defaults to `4173`.
+- `PROJECT_CONNECTOR_HUB_URL` publishes this machine to the hosted Project Space UI.
+- `PROJECT_CONNECTOR_SERVICE_NAME` is the service label shown on machine cards.
 - `PROJECT_SPACE_PRIVATE_VPS_BASE_URL` is optional until deployments/backups are wired to the VPS platform.
 - `PROJECT_SPACE_CONNECTOR_ORIGIN` is optional metadata shown in the UI.
 
@@ -99,4 +103,3 @@ If the UI shows no projects:
 3. Check Tailscale Serve with `tailscale serve status --json`.
 4. Open the Vercel UI with `?projectSpaceApi=<tailscale-https-url>`.
 5. If deployments/backups are offline, set `PROJECT_SPACE_PRIVATE_VPS_BASE_URL`.
-

--- a/server/connector-hub.ts
+++ b/server/connector-hub.ts
@@ -1,0 +1,124 @@
+import type {
+  ConnectorProjectRegistryResult,
+  MachineRecord,
+  ProjectDiscoveryResult,
+  ProjectNavigationItem,
+  ProjectSpaceRecord
+} from '../src/shared/project-space-api';
+
+interface RegisteredConnector {
+  receivedAt: string;
+  registry: ConnectorProjectRegistryResult;
+}
+
+const registryTtlMs = 2 * 60 * 1000;
+const registries = new Map<string, RegisteredConnector>();
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function isFresh(entry: RegisteredConnector) {
+  return Date.now() - Date.parse(entry.receivedAt) <= registryTtlMs;
+}
+
+function pruneStaleRegistries() {
+  for (const [machineId, entry] of registries.entries()) {
+    if (!isFresh(entry)) {
+      registries.delete(machineId);
+    }
+  }
+}
+
+function normalizeProject(machineId: string, project: ProjectSpaceRecord): ProjectSpaceRecord {
+  if (project.id.includes(':')) {
+    return project;
+  }
+
+  return {
+    ...project,
+    id: `${machineId}:${project.id}`
+  };
+}
+
+function normalizeRootItem(
+  machineId: string,
+  item: ProjectNavigationItem
+): ProjectNavigationItem {
+  if (item.kind !== 'project' || !item.projectId || item.projectId.includes(':')) {
+    return item;
+  }
+
+  return {
+    ...item,
+    id: `${machineId}:${item.id}`,
+    projectId: `${machineId}:${item.projectId}`
+  };
+}
+
+export function registerConnectorProjectRegistry(registry: ConnectorProjectRegistryResult) {
+  const machineId = registry.connector.machineId.trim();
+
+  if (!machineId) {
+    throw new Error('Connector registry is missing connector.machineId.');
+  }
+
+  registries.set(machineId, {
+    receivedAt: nowIso(),
+    registry
+  });
+}
+
+export function getRegisteredConnectorRegistries() {
+  pruneStaleRegistries();
+
+  return [...registries.values()].sort((left, right) =>
+    left.registry.connector.machineName.localeCompare(right.registry.connector.machineName)
+  );
+}
+
+export function getRegisteredConnectorMachines(): MachineRecord[] {
+  return getRegisteredConnectorRegistries().map(({ receivedAt, registry }) => ({
+    connector: {
+      installCommand: 'project-space-connector',
+      lastSeen: receivedAt,
+      origin: registry.connector.origin,
+      serviceName: registry.connector.serviceName ?? 'project-space-connector',
+      status: 'online'
+    },
+    id: registry.connector.machineId,
+    kind: 'connector',
+    name: registry.connector.machineName,
+    network: {},
+    roles: ['connector'],
+    sourcePath: 'connector-hub'
+  }));
+}
+
+export function getRegisteredConnectorDiscovery(): ProjectDiscoveryResult {
+  const entries = getRegisteredConnectorRegistries();
+  const projects: ProjectSpaceRecord[] = [];
+  const rootItems: ProjectNavigationItem[] = [];
+
+  for (const { registry } of entries) {
+    const machineId = registry.connector.machineId;
+    const nextProjects = registry.discovery.projects.map((project) =>
+      normalizeProject(machineId, project)
+    );
+
+    projects.push(...nextProjects);
+    rootItems.push(
+      ...registry.discovery.rootItems.map((item) => normalizeRootItem(machineId, item))
+    );
+  }
+
+  return {
+    groups: [],
+    projects: projects.sort((left, right) => left.name.localeCompare(right.name)),
+    rootItems: rootItems.sort((left, right) => left.label.localeCompare(right.label)),
+    rootPath: entries
+      .map(({ registry }) => registry.discovery.rootPath)
+      .filter(Boolean)
+      .join(', ')
+  };
+}

--- a/server/local-machine-registry.ts
+++ b/server/local-machine-registry.ts
@@ -78,6 +78,7 @@ function parseHostFile(path: string): MachineRecord {
     connector: {
       installCommand: 'project-space connector install',
       origin: isLocal ? process.env.PROJECT_SPACE_CONNECTOR_ORIGIN : undefined,
+      serviceName: process.env.PROJECT_CONNECTOR_SERVICE_NAME ?? 'project-space-connector',
       status: isLocal ? 'local' : 'not-installed'
     },
     id: name,
@@ -165,6 +166,7 @@ export async function getConnectorOverview(): Promise<ConnectorOverviewResult> {
           ...machine.connector,
           lastSeen: new Date().toISOString(),
           origin: process.env.PROJECT_SPACE_CONNECTOR_ORIGIN,
+          serviceName: process.env.PROJECT_CONNECTOR_SERVICE_NAME ?? 'project-space-connector',
           status: 'local' as const
         },
         network: {
@@ -184,6 +186,7 @@ export async function getConnectorOverview(): Promise<ConnectorOverviewResult> {
         installCommand: 'project-space connector install',
         lastSeen: new Date().toISOString(),
         origin: process.env.PROJECT_SPACE_CONNECTOR_ORIGIN,
+        serviceName: process.env.PROJECT_CONNECTOR_SERVICE_NAME ?? 'project-space-connector',
         status: 'local'
       },
       id: currentHost,

--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -9,6 +9,10 @@ import { getCodexStatus, openCodexTarget } from './local-codex-client';
 import { runTerminalCommand } from './local-command-runner';
 import { loadConnectorProjectDiscovery } from './connector-discovery';
 import {
+  getRegisteredConnectorDiscovery,
+  getRegisteredConnectorMachines
+} from './connector-hub';
+import {
   commitGitChanges,
   getGitDiff,
   getGitStatus,
@@ -287,6 +291,22 @@ function writeProjectsState(state: ProjectsState) {
   writeFileSync(projectsStateFile, JSON.stringify(state, null, 2));
 }
 
+function mergeDiscoveries(
+  localDiscovery: ProjectDiscoveryResult,
+  remoteDiscovery: ProjectDiscoveryResult
+): ProjectDiscoveryResult {
+  return {
+    groups: [...localDiscovery.groups, ...remoteDiscovery.groups],
+    projects: [...localDiscovery.projects, ...remoteDiscovery.projects].sort((left, right) =>
+      left.name.localeCompare(right.name)
+    ),
+    rootItems: [...localDiscovery.rootItems, ...remoteDiscovery.rootItems].sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+    rootPath: [localDiscovery.rootPath, remoteDiscovery.rootPath].filter(Boolean).join(', ')
+  };
+}
+
 async function discoverProjects(): Promise<ProjectDiscoveryResult> {
   if (!existsSync(discoveryRoot)) {
     return {
@@ -535,7 +555,17 @@ export function createLocalProjectSpaceBackend(
       return getCodexStatus();
     },
     async getConnectorOverview() {
-      return getConnectorOverview();
+      const connector = await getConnectorOverview();
+      const registeredMachines = getRegisteredConnectorMachines();
+      const knownMachineIds = new Set(connector.machines.map((machine) => machine.id));
+
+      return {
+        ...connector,
+        machines: [
+          ...connector.machines,
+          ...registeredMachines.filter((machine) => !knownMachineIds.has(machine.id))
+        ]
+      };
     },
     async getConnectorProjectRegistry() {
       const [connector, discovery] = await Promise.all([
@@ -552,7 +582,8 @@ export function createLocalProjectSpaceBackend(
         connector: {
           machineId: localMachine?.id ?? machineName,
           machineName,
-          origin: connector.connectorOrigin
+          origin: connector.connectorOrigin,
+          serviceName: process.env.PROJECT_CONNECTOR_SERVICE_NAME ?? 'project-space-connector'
         },
         discovery
       };
@@ -588,7 +619,7 @@ export function createLocalProjectSpaceBackend(
         };
       }
 
-      return discoverProjects();
+      return mergeDiscoveries(await discoverProjects(), getRegisteredConnectorDiscovery());
     },
     async loadProjectctlOverview(projectPath: string) {
       return getProjectctlOverview(projectPath);

--- a/server/project-connector-websocket.ts
+++ b/server/project-connector-websocket.ts
@@ -11,6 +11,7 @@ interface ConnectorCommandMessage {
 
 interface ProjectConnectorWebSocketOptions {
   backend: ProjectSpaceBackend;
+  hubHttpUrl?: string;
   hubUrl?: string;
 }
 
@@ -33,23 +34,71 @@ function parseMessage(data: MessageEvent['data']) {
 
 export function startProjectConnectorWebSocket({
   backend,
+  hubHttpUrl = process.env.PROJECT_CONNECTOR_HUB_URL,
   hubUrl = process.env.PROJECT_CONNECTOR_HUB_WS_URL
 }: ProjectConnectorWebSocketOptions) {
-  if (!hubUrl) {
+  if (!hubUrl && !hubHttpUrl) {
     return {
       close() {}
+    };
+  }
+
+  const resolvedHubHttpUrl = hubHttpUrl?.replace(/\/+$/, '');
+  let httpRegistryTimer: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+
+  async function publishRegistryToHttpHub() {
+    if (!resolvedHubHttpUrl) {
+      return;
+    }
+
+    const registry = await backend.getConnectorProjectRegistry();
+    await fetch(`${resolvedHubHttpUrl}/api/connectors/project-registry`, {
+      body: JSON.stringify(registry),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    }).catch((error) => {
+      console.warn(
+        `Could not publish connector registry to ${resolvedHubHttpUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    });
+  }
+
+  if (resolvedHubHttpUrl) {
+    void publishRegistryToHttpHub();
+    httpRegistryTimer = setInterval(() => {
+      void publishRegistryToHttpHub();
+    }, registryIntervalMs);
+  }
+
+  if (!hubUrl) {
+    return {
+      close() {
+        closed = true;
+        if (httpRegistryTimer) {
+          clearInterval(httpRegistryTimer);
+        }
+      }
     };
   }
 
   if (typeof WebSocket === 'undefined') {
     console.warn('PROJECT_CONNECTOR_HUB_WS_URL is set, but WebSocket is not available.');
     return {
-      close() {}
+      close() {
+        closed = true;
+        if (httpRegistryTimer) {
+          clearInterval(httpRegistryTimer);
+        }
+      }
     };
   }
 
   const resolvedHubUrl = hubUrl;
-  let closed = false;
   let socket: WebSocket | undefined;
   let registryTimer: ReturnType<typeof setInterval> | undefined;
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -78,7 +127,7 @@ export function startProjectConnectorWebSocket({
   }
 
   function connect() {
-    if (closed) {
+    if (closed || !resolvedHubUrl) {
       return;
     }
 
@@ -129,6 +178,9 @@ export function startProjectConnectorWebSocket({
   return {
     close() {
       closed = true;
+      if (httpRegistryTimer) {
+        clearInterval(httpRegistryTimer);
+      }
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
       }

--- a/server/project-space-http.ts
+++ b/server/project-space-http.ts
@@ -3,7 +3,9 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { extname, join, normalize, resolve } from 'node:path';
 
 import { createLocalProjectSpaceBackend } from './local-project-space-backend';
+import { registerConnectorProjectRegistry } from './connector-hub';
 import type {
+  ConnectorProjectRegistryResult,
   OpenPathInAppRequest,
   CodexOpenRequest,
   GitHubOAuthDevicePollRequest,
@@ -199,6 +201,13 @@ function createApiHandler(backend: ProjectSpaceBackend) {
 
       if (request.method === 'GET' && url.pathname === '/api/connectors/project-registry') {
         writeJson(response, 200, await backend.getConnectorProjectRegistry());
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/connectors/project-registry') {
+        const payload = await readJson<ConnectorProjectRegistryResult>(request);
+        registerConnectorProjectRegistry(payload);
+        writeJson(response, 200, { ok: true });
         return true;
       }
 

--- a/src/features/project-desktop/components/project-home-overview.tsx
+++ b/src/features/project-desktop/components/project-home-overview.tsx
@@ -562,6 +562,11 @@ export function ProjectHomeOverview({
                   </div>
 
                   <div className="mt-4 flex flex-wrap gap-2">
+                    {machine.connector.serviceName ? (
+                      <Chip size="sm" variant="secondary">
+                        {machine.connector.serviceName}
+                      </Chip>
+                    ) : null}
                     <Chip size="sm" className={connectorChipClass(machine.connector.status)}>
                       {machine.connector.status}
                     </Chip>

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -280,6 +280,7 @@ export interface MachineConnectorRecord {
   installCommand: string;
   lastSeen?: string;
   origin?: string;
+  serviceName?: string;
   status: ConnectorStatus;
 }
 
@@ -326,6 +327,7 @@ export interface ConnectorProjectRegistryResult {
     machineId: string;
     machineName: string;
     origin?: string;
+    serviceName?: string;
   };
   discovery: ProjectDiscoveryResult;
 }


### PR DESCRIPTION
Adds a hosted connector registry endpoint so local Project Space connectors can publish their machine/project state to the public web UI. Also shows connector service names on machine cards and configures the Homebrew service to publish to projects.os-home.net.