### PR TITLE
Prefer online connector machines

### DIFF
--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -558,11 +558,17 @@ export function createLocalProjectSpaceBackend(
       const connector = await getConnectorOverview();
       const registeredMachines = getRegisteredConnectorMachines();
       const knownMachineIds = new Set(connector.machines.map((machine) => machine.id));
+      const localMachines =
+        registeredMachines.length > 0
+          ? connector.machines.filter(
+              (machine) => machine.connector.serviceName !== 'project-space-web'
+            )
+          : connector.machines;
 
       return {
         ...connector,
         machines: [
-          ...connector.machines,
+          ...localMachines,
           ...registeredMachines.filter((machine) => !knownMachineIds.has(machine.id))
         ]
       };


### PR DESCRIPTION
Hides the project-space-web service machine once real connector machines have published to the hosted registry, so the Machines view defaults to actual dev machines instead of the VPS web container.