### PR TITLE
Select first connector machine by default

### DIFF
--- a/src/features/project-desktop/components/project-home-overview.tsx
+++ b/src/features/project-desktop/components/project-home-overview.tsx
@@ -404,7 +404,9 @@ export function ProjectHomeOverview({
     [machines]
   );
   const localMachineId =
-    machines.find((machine) => machine.connector.status === 'local')?.id ?? 'local';
+    machines.find((machine) => machine.connector.status === 'local')?.id ??
+    machines[0]?.id ??
+    'local';
   const activeMachineId = selectedMachineId || localMachineId || machines[0]?.id || '';
   const activeMachine = machinesById.get(activeMachineId);
 


### PR DESCRIPTION
When the hosted UI only has online connector machines and no local machine, select the first real connector machine instead of falling back to the synthetic local id.