### PR TITLE
Expose OAuth config and machine battery

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -6,6 +6,7 @@ services:
       context: ..
       dockerfile: deploy/Dockerfile
     environment:
+      GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID:-}
       PROJECT_CONNECTOR_SERVICE_NAME: project-space-web
     image: project-space-web:local
     restart: unless-stopped

--- a/server/connector-hub.ts
+++ b/server/connector-hub.ts
@@ -79,6 +79,7 @@ export function getRegisteredConnectorRegistries() {
 
 export function getRegisteredConnectorMachines(): MachineRecord[] {
   return getRegisteredConnectorRegistries().map(({ receivedAt, registry }) => ({
+    battery: registry.connector.battery,
     connector: {
       installCommand: 'project-space-connector',
       lastSeen: receivedAt,

--- a/server/local-github-catalog.ts
+++ b/server/local-github-catalog.ts
@@ -50,9 +50,15 @@ const githubTokenFile = join(projectSpaceDirectory, 'github-oauth.json');
 const githubApiBaseUrl = 'https://api.github.com';
 const githubDeviceCodeUrl = 'https://github.com/login/device/code';
 const githubAccessTokenUrl = 'https://github.com/login/oauth/access_token';
+const githubOAuthClientIdMissingMessage = 'Set GITHUB_OAUTH_CLIENT_ID to enable GitHub OAuth.';
 
 function getGitHubClientId() {
-  return process.env.PROJECT_SPACE_GITHUB_CLIENT_ID ?? process.env.GITHUB_CLIENT_ID ?? '';
+  return (
+    process.env.GITHUB_OAUTH_CLIENT_ID ??
+    process.env.PROJECT_SPACE_GITHUB_CLIENT_ID ??
+    process.env.GITHUB_CLIENT_ID ??
+    ''
+  );
 }
 
 function createEmptyCatalog(
@@ -258,7 +264,7 @@ export async function getGitHubCatalog(): Promise<GitHubCatalogResult> {
       getGitHubClientId() ? 'auth-required' : 'not-configured',
       getGitHubClientId()
         ? 'Connect GitHub to load the remote project catalog.'
-        : 'Set PROJECT_SPACE_GITHUB_CLIENT_ID to enable GitHub OAuth.'
+        : githubOAuthClientIdMissingMessage
     );
   }
 
@@ -291,7 +297,7 @@ export async function startGitHubOAuthDeviceFlow(): Promise<GitHubOAuthDeviceSta
 
   if (!clientId) {
     return {
-      message: 'Set PROJECT_SPACE_GITHUB_CLIENT_ID to enable GitHub OAuth.',
+      message: githubOAuthClientIdMissingMessage,
       status: 'not-configured'
     };
   }
@@ -340,7 +346,7 @@ export async function pollGitHubOAuthDeviceFlow({
 
   if (!clientId) {
     return {
-      message: 'Set PROJECT_SPACE_GITHUB_CLIENT_ID to enable GitHub OAuth.',
+      message: githubOAuthClientIdMissingMessage,
       status: 'error'
     };
   }

--- a/server/local-machine-registry.ts
+++ b/server/local-machine-registry.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 
 import type {
   ConnectorOverviewResult,
+  MachineBatteryRecord,
   MachineRecord,
   TailscaleStatusResult
 } from '../src/shared/project-space-api';
@@ -28,6 +29,86 @@ function parseScalar(line: string, key: string) {
   const match = line.match(new RegExp(`^${key}:\\s*(.+?)\\s*$`));
 
   return match?.[1]?.replace(/^["']|["']$/g, '');
+}
+
+function normalizeBatteryState(value: string | undefined): MachineBatteryRecord['state'] {
+  const state = value?.trim().toLowerCase();
+
+  if (state === 'charging') {
+    return 'charging';
+  }
+
+  if (state === 'discharging') {
+    return 'discharging';
+  }
+
+  if (state === 'charged' || state === 'full') {
+    return 'charged';
+  }
+
+  return state ? 'unknown' : undefined;
+}
+
+async function loadMacBatteryStatus(): Promise<MachineBatteryRecord | undefined> {
+  const output = await run('pmset', ['-g', 'batt']);
+  const match = output.match(/(\d{1,3})%;\s*([^;]+)/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    percentage: Math.max(0, Math.min(100, Number(match[1]))),
+    state: normalizeBatteryState(match[2])
+  };
+}
+
+async function loadLinuxBatteryStatus(): Promise<MachineBatteryRecord | undefined> {
+  const powerSupplyPath = '/sys/class/power_supply';
+
+  if (!existsSync(powerSupplyPath)) {
+    return undefined;
+  }
+
+  const entries = await readdir(powerSupplyPath, {
+    withFileTypes: true
+  });
+  const battery = entries.find((entry) => entry.name.toLowerCase().startsWith('bat'));
+
+  if (!battery) {
+    return undefined;
+  }
+
+  const batteryPath = join(powerSupplyPath, battery.name);
+  const capacity = Number(readFileSync(join(batteryPath, 'capacity'), 'utf-8').trim());
+  const state = existsSync(join(batteryPath, 'status'))
+    ? readFileSync(join(batteryPath, 'status'), 'utf-8').trim()
+    : undefined;
+
+  if (!Number.isFinite(capacity)) {
+    return undefined;
+  }
+
+  return {
+    percentage: Math.max(0, Math.min(100, capacity)),
+    state: normalizeBatteryState(state)
+  };
+}
+
+export async function loadBatteryStatus(): Promise<MachineBatteryRecord | undefined> {
+  try {
+    if (platform() === 'darwin') {
+      return await loadMacBatteryStatus();
+    }
+
+    if (platform() === 'linux') {
+      return await loadLinuxBatteryStatus();
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
 }
 
 function parseHostFile(path: string): MachineRecord {
@@ -149,7 +230,11 @@ async function loadMachines() {
 }
 
 export async function getConnectorOverview(): Promise<ConnectorOverviewResult> {
-  const [tailscale, machines] = await Promise.all([loadTailscaleStatus(), loadMachines()]);
+  const [tailscale, machines, battery] = await Promise.all([
+    loadTailscaleStatus(),
+    loadMachines(),
+    loadBatteryStatus()
+  ]);
 
   const currentHost = hostname().split('.')[0];
   const machinesWithTailscale = machines.map((machine) => {
@@ -162,6 +247,7 @@ export async function getConnectorOverview(): Promise<ConnectorOverviewResult> {
     if (isLocal) {
       return {
         ...machine,
+        battery,
         connector: {
           ...machine.connector,
           lastSeen: new Date().toISOString(),
@@ -182,6 +268,7 @@ export async function getConnectorOverview(): Promise<ConnectorOverviewResult> {
 
   if (!hasLocalMachine) {
     machinesWithTailscale.unshift({
+      battery,
       connector: {
         installCommand: 'project-space connector install',
         lastSeen: new Date().toISOString(),

--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -586,6 +586,7 @@ export function createLocalProjectSpaceBackend(
       return {
         checkedAt: new Date().toISOString(),
         connector: {
+          battery: localMachine?.battery,
           machineId: localMachine?.id ?? machineName,
           machineName,
           origin: connector.connectorOrigin,

--- a/src/features/project-desktop/components/project-home-overview.tsx
+++ b/src/features/project-desktop/components/project-home-overview.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Battery,
+  BatteryCharging,
   ChevronDown,
   ExternalLink,
   Github,
@@ -169,6 +171,36 @@ function formatLastSeen(value?: string) {
 
   const hours = Math.round(minutes / 60);
   return hours < 24 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+}
+
+function formatBattery(machine: MachineRecord) {
+  if (!machine.battery) {
+    return undefined;
+  }
+
+  const suffix =
+    machine.battery.state && machine.battery.state !== 'unknown'
+      ? ` ${machine.battery.state}`
+      : '';
+
+  return `${machine.battery.percentage}%${suffix}`;
+}
+
+function BatteryIcon({ machine }: { machine: MachineRecord }) {
+  return machine.battery?.state === 'charging' ? (
+    <BatteryCharging className="size-3.5" />
+  ) : (
+    <Battery className="size-3.5" />
+  );
+}
+
+function BatteryChipContent({ machine, label }: { label: string; machine: MachineRecord }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <BatteryIcon machine={machine} />
+      {label}
+    </span>
+  );
 }
 
 function MachineIcon({ machine }: { machine: MachineRecord }) {
@@ -529,6 +561,7 @@ export function ProjectHomeOverview({
               const isOnline =
                 machine.connector.status === 'local' || machine.connector.status === 'online';
               const isSelected = machine.id === activeMachineId;
+              const batteryLabel = formatBattery(machine);
 
               return (
                 <button
@@ -575,6 +608,11 @@ export function ProjectHomeOverview({
                     <Chip size="sm" variant="tertiary">
                       {machineProjects.length} projects
                     </Chip>
+                    {batteryLabel ? (
+                      <Chip size="sm" variant="tertiary">
+                        <BatteryChipContent label={batteryLabel} machine={machine} />
+                      </Chip>
+                    ) : null}
                     <Chip size="sm" variant="tertiary">
                       {formatLastSeen(machine.connector.lastSeen)}
                     </Chip>
@@ -685,6 +723,11 @@ export function ProjectHomeOverview({
                       <Chip size="sm" className={connectorChipClass(machine.connector.status)}>
                         {machine.connector.status}
                       </Chip>
+                      {formatBattery(machine) ? (
+                        <Chip size="sm" variant="tertiary">
+                          <BatteryChipContent label={formatBattery(machine) ?? ''} machine={machine} />
+                        </Chip>
+                      ) : null}
                       <Chip size="sm" variant="tertiary">
                         {formatLastSeen(machine.connector.lastSeen)}
                       </Chip>

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -284,10 +284,16 @@ export interface MachineConnectorRecord {
   status: ConnectorStatus;
 }
 
+export interface MachineBatteryRecord {
+  percentage: number;
+  state?: 'charged' | 'charging' | 'discharging' | 'unknown';
+}
+
 export interface MachineRecord {
   id: string;
   kind: string;
   name: string;
+  battery?: MachineBatteryRecord;
   primaryUser?: string;
   profile?: string;
   roles: string[];
@@ -324,6 +330,7 @@ export interface ConnectorOverviewResult {
 export interface ConnectorProjectRegistryResult {
   checkedAt: string;
   connector: {
+    battery?: MachineBatteryRecord;
     machineId: string;
     machineName: string;
     origin?: string;


### PR DESCRIPTION
## Summary
- prefer GITHUB_OAUTH_CLIENT_ID for GitHub OAuth while keeping legacy fallbacks
- publish local battery status through connector APIs
- show service name and battery in machine cards

## Verification
- bun run check
- bun run build
- go test ./...