### PR TITLE
Require GitHub login for connector access

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID:-}
+      PROJECT_SPACE_ALLOWED_GITHUB_LOGINS: ${PROJECT_SPACE_ALLOWED_GITHUB_LOGINS:-}
+      PROJECT_SPACE_AUTH_DISABLED: ${PROJECT_SPACE_AUTH_DISABLED:-}
       PROJECT_CONNECTOR_SERVICE_NAME: project-space-web
     image: project-space-web:local
     restart: unless-stopped

--- a/server/local-auth-store.ts
+++ b/server/local-auth-store.ts
@@ -1,0 +1,475 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHash, randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import type { IncomingMessage } from 'node:http';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type {
+  ProjectSpaceAuthDevicePollRequest,
+  ProjectSpaceAuthDevicePollResult,
+  ProjectSpaceAuthDeviceStartResult,
+  ProjectSpaceAuthSessionResult
+} from '../src/shared/project-space-api';
+
+interface StoredAuthUser {
+  createdAt: string;
+  githubAccessToken: string;
+  githubScope?: string;
+  githubTokenType?: string;
+  login: string;
+  role: 'owner' | 'user';
+  updatedAt: string;
+}
+
+interface StoredAuthSession {
+  createdAt: string;
+  expiresAt: string;
+  tokenHash: string;
+  userLogin: string;
+}
+
+interface AuthDatabase {
+  sessions: StoredAuthSession[];
+  users: StoredAuthUser[];
+  version: 1;
+}
+
+export interface ProjectSpaceAuthSession {
+  expiresAt: string;
+  githubAccessToken: string;
+  login: string;
+  role: 'owner' | 'user';
+  tokenHash: string;
+}
+
+const authContext = new AsyncLocalStorage<ProjectSpaceAuthSession | null>();
+const projectSpaceDirectory = join(homedir(), '.project-space');
+const authDatabaseFile = join(projectSpaceDirectory, 'project-space-auth.db.json');
+const githubApiBaseUrl = 'https://api.github.com';
+const githubDeviceCodeUrl = 'https://github.com/login/device/code';
+const githubAccessTokenUrl = 'https://github.com/login/oauth/access_token';
+const sessionDurationMs = 1000 * 60 * 60 * 24 * 30;
+const githubOAuthClientIdMissingMessage = 'Set GITHUB_OAUTH_CLIENT_ID to enable GitHub OAuth.';
+
+function getGitHubClientId() {
+  return (
+    process.env.GITHUB_OAUTH_CLIENT_ID ??
+    process.env.PROJECT_SPACE_GITHUB_CLIENT_ID ??
+    process.env.GITHUB_CLIENT_ID ??
+    ''
+  );
+}
+
+export function isProjectSpaceAuthRequired() {
+  return process.env.PROJECT_SPACE_AUTH_DISABLED !== '1';
+}
+
+function readAllowedLogins() {
+  return new Set(
+    (process.env.PROJECT_SPACE_ALLOWED_GITHUB_LOGINS ?? '')
+      .split(',')
+      .map((login) => login.trim().replace(/^@/, '').toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function emptyDatabase(): AuthDatabase {
+  return {
+    sessions: [],
+    users: [],
+    version: 1
+  };
+}
+
+function readDatabase(): AuthDatabase {
+  if (!existsSync(authDatabaseFile)) {
+    return emptyDatabase();
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(authDatabaseFile, 'utf-8')) as Partial<AuthDatabase>;
+
+    return {
+      sessions: Array.isArray(parsed.sessions) ? parsed.sessions : [],
+      users: Array.isArray(parsed.users) ? parsed.users : [],
+      version: 1
+    };
+  } catch {
+    return emptyDatabase();
+  }
+}
+
+function writeDatabase(database: AuthDatabase) {
+  mkdirSync(projectSpaceDirectory, { recursive: true });
+  writeFileSync(authDatabaseFile, JSON.stringify(database, null, 2), {
+    mode: 0o600
+  });
+}
+
+function hashToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function isExpired(expiresAt: string) {
+  return Date.parse(expiresAt) <= Date.now();
+}
+
+function sanitizeDatabase(database: AuthDatabase) {
+  return {
+    ...database,
+    sessions: database.sessions.filter((session) => !isExpired(session.expiresAt))
+  };
+}
+
+async function requestGitHub<T>(
+  path: string,
+  token: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${githubApiBaseUrl}${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...init.headers
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub request failed with ${response.status}.`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function readGitHubLogin(token: string) {
+  const user = await requestGitHub<{ login?: string }>('/user', token);
+
+  if (!user.login) {
+    throw new Error('GitHub did not return a login.');
+  }
+
+  return user.login;
+}
+
+function authorizeLogin(database: AuthDatabase, login: string) {
+  const normalizedLogin = login.toLowerCase();
+  const allowedLogins = readAllowedLogins();
+
+  if (allowedLogins.size > 0) {
+    return allowedLogins.has(normalizedLogin);
+  }
+
+  return (
+    database.users.length === 0 ||
+    database.users.some((user) => user.login.toLowerCase() === normalizedLogin)
+  );
+}
+
+function upsertUser(
+  database: AuthDatabase,
+  login: string,
+  payload: {
+    accessToken: string;
+    scope?: string;
+    tokenType?: string;
+  }
+) {
+  const now = new Date().toISOString();
+  const existingUser = database.users.find(
+    (user) => user.login.toLowerCase() === login.toLowerCase()
+  );
+
+  if (existingUser) {
+    existingUser.githubAccessToken = payload.accessToken;
+    existingUser.githubScope = payload.scope;
+    existingUser.githubTokenType = payload.tokenType;
+    existingUser.updatedAt = now;
+    return existingUser;
+  }
+
+  const user: StoredAuthUser = {
+    createdAt: now,
+    githubAccessToken: payload.accessToken,
+    githubScope: payload.scope,
+    githubTokenType: payload.tokenType,
+    login,
+    role: database.users.length === 0 ? 'owner' : 'user',
+    updatedAt: now
+  };
+
+  database.users.push(user);
+
+  return user;
+}
+
+function createSession(database: AuthDatabase, user: StoredAuthUser) {
+  const token = randomBytes(32).toString('base64url');
+  const session: StoredAuthSession = {
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + sessionDurationMs).toISOString(),
+    tokenHash: hashToken(token),
+    userLogin: user.login
+  };
+
+  database.sessions.push(session);
+
+  return {
+    session,
+    token
+  };
+}
+
+export function getCurrentAuthSession() {
+  return authContext.getStore() ?? null;
+}
+
+export function runWithAuthSession<T>(
+  session: ProjectSpaceAuthSession | null,
+  callback: () => T
+) {
+  return authContext.run(session, callback);
+}
+
+export function getCurrentGitHubToken() {
+  return getCurrentAuthSession()?.githubAccessToken;
+}
+
+export function readProjectSpaceAuthSession(token?: string | null) {
+  if (!token) {
+    return null;
+  }
+
+  const database = sanitizeDatabase(readDatabase());
+  const tokenHash = hashToken(token);
+  const storedSession = database.sessions.find((session) => session.tokenHash === tokenHash);
+
+  if (!storedSession || isExpired(storedSession.expiresAt)) {
+    writeDatabase(database);
+    return null;
+  }
+
+  const user = database.users.find(
+    (entry) => entry.login.toLowerCase() === storedSession.userLogin.toLowerCase()
+  );
+
+  if (!user) {
+    return null;
+  }
+
+  return {
+    expiresAt: storedSession.expiresAt,
+    githubAccessToken: user.githubAccessToken,
+    login: user.login,
+    role: user.role,
+    tokenHash
+  } satisfies ProjectSpaceAuthSession;
+}
+
+export function readAuthTokenFromRequest(request: IncomingMessage) {
+  const authHeader = request.headers.authorization;
+
+  if (authHeader?.toLowerCase().startsWith('bearer ')) {
+    return authHeader.slice('bearer '.length).trim();
+  }
+
+  return null;
+}
+
+export function readAuthSessionFromRequest(request: IncomingMessage) {
+  if (!isProjectSpaceAuthRequired()) {
+    return null;
+  }
+
+  return readProjectSpaceAuthSession(readAuthTokenFromRequest(request));
+}
+
+export function readAuthSessionFromUrl(url: URL) {
+  if (!isProjectSpaceAuthRequired()) {
+    return null;
+  }
+
+  return readProjectSpaceAuthSession(url.searchParams.get('session'));
+}
+
+export function getProjectSpaceAuthSessionResult(
+  token?: string | null
+): ProjectSpaceAuthSessionResult {
+  if (!isProjectSpaceAuthRequired()) {
+    return {
+      authenticated: true,
+      authRequired: false
+    };
+  }
+
+  const session = readProjectSpaceAuthSession(token);
+
+  if (!session) {
+    return {
+      authenticated: false,
+      authRequired: true
+    };
+  }
+
+  return {
+    authenticated: true,
+    authRequired: true,
+    expiresAt: session.expiresAt,
+    user: {
+      login: session.login,
+      role: session.role
+    }
+  };
+}
+
+export async function startProjectSpaceAuthDeviceFlow(): Promise<ProjectSpaceAuthDeviceStartResult> {
+  const clientId = getGitHubClientId();
+
+  if (!clientId) {
+    return {
+      message: githubOAuthClientIdMissingMessage,
+      status: 'not-configured'
+    };
+  }
+
+  const response = await fetch(githubDeviceCodeUrl, {
+    body: new URLSearchParams({
+      client_id: clientId,
+      scope: 'repo read:user'
+    }),
+    headers: {
+      Accept: 'application/json'
+    },
+    method: 'POST'
+  });
+  const payload = (await response.json()) as {
+    device_code?: string;
+    error?: string;
+    error_description?: string;
+    expires_in?: number;
+    interval?: number;
+    user_code?: string;
+    verification_uri?: string;
+  };
+
+  if (!response.ok || !payload.device_code) {
+    return {
+      message: payload.error_description ?? payload.error ?? 'Could not start GitHub login.',
+      status: 'error'
+    };
+  }
+
+  return {
+    deviceCode: payload.device_code,
+    expiresAt: new Date(Date.now() + (payload.expires_in ?? 900) * 1000).toISOString(),
+    intervalSeconds: payload.interval ?? 5,
+    status: 'pending',
+    userCode: payload.user_code,
+    verificationUri: payload.verification_uri
+  };
+}
+
+export async function pollProjectSpaceAuthDeviceFlow({
+  deviceCode
+}: ProjectSpaceAuthDevicePollRequest): Promise<ProjectSpaceAuthDevicePollResult> {
+  const clientId = getGitHubClientId();
+
+  if (!clientId) {
+    return {
+      message: githubOAuthClientIdMissingMessage,
+      status: 'error'
+    };
+  }
+
+  const response = await fetch(githubAccessTokenUrl, {
+    body: new URLSearchParams({
+      client_id: clientId,
+      device_code: deviceCode,
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code'
+    }),
+    headers: {
+      Accept: 'application/json'
+    },
+    method: 'POST'
+  });
+  const payload = (await response.json()) as {
+    access_token?: string;
+    error?: string;
+    error_description?: string;
+    interval?: number;
+    scope?: string;
+    token_type?: string;
+  };
+
+  if (payload.error === 'authorization_pending' || payload.error === 'slow_down') {
+    return {
+      intervalSeconds: payload.interval,
+      message: payload.error_description,
+      status: 'pending'
+    };
+  }
+
+  if (payload.error === 'expired_token') {
+    return {
+      message: payload.error_description,
+      status: 'expired'
+    };
+  }
+
+  if (payload.error === 'access_denied') {
+    return {
+      message: payload.error_description,
+      status: 'denied'
+    };
+  }
+
+  if (!response.ok || !payload.access_token) {
+    return {
+      message: payload.error_description ?? payload.error ?? 'Could not finish GitHub login.',
+      status: 'error'
+    };
+  }
+
+  const login = await readGitHubLogin(payload.access_token);
+  const database = sanitizeDatabase(readDatabase());
+
+  if (!authorizeLogin(database, login)) {
+    writeDatabase(database);
+    return {
+      message: `@${login} is not allowed to use this Project Space connector.`,
+      status: 'denied'
+    };
+  }
+
+  const user = upsertUser(database, login, {
+    accessToken: payload.access_token,
+    scope: payload.scope,
+    tokenType: payload.token_type
+  });
+  const { session, token } = createSession(database, user);
+
+  writeDatabase(database);
+
+  return {
+    sessionToken: token,
+    status: 'connected',
+    user: {
+      login: user.login,
+      role: user.role
+    },
+    expiresAt: session.expiresAt
+  };
+}
+
+export function revokeProjectSpaceAuthSession(token?: string | null) {
+  if (!token) {
+    return;
+  }
+
+  const tokenHash = hashToken(token);
+  const database = readDatabase();
+  database.sessions = database.sessions.filter((session) => session.tokenHash !== tokenHash);
+  writeDatabase(database);
+}

--- a/server/local-github-catalog.ts
+++ b/server/local-github-catalog.ts
@@ -14,6 +14,11 @@ import type {
   GitHubRepositoryDetailsResult,
   GitHubProjectConfigStatus
 } from '../src/shared/project-space-api';
+import {
+  getCurrentAuthSession,
+  getCurrentGitHubToken,
+  isProjectSpaceAuthRequired
+} from './local-auth-store';
 
 interface StoredGitHubToken {
   accessToken: string;
@@ -150,6 +155,22 @@ async function readLogin(token: string) {
 }
 
 async function resolveToken(): Promise<TokenResolution | null> {
+  const sessionToken = getCurrentGitHubToken();
+
+  if (sessionToken) {
+    const session = getCurrentAuthSession();
+
+    return {
+      login: session?.login,
+      source: 'stored-oauth',
+      token: sessionToken
+    };
+  }
+
+  if (isProjectSpaceAuthRequired() && process.env.PROJECT_SPACE_ALLOW_GLOBAL_GITHUB_TOKEN !== '1') {
+    return null;
+  }
+
   const stored = readStoredToken();
 
   if (stored) {

--- a/server/machine-terminal-websocket.ts
+++ b/server/machine-terminal-websocket.ts
@@ -8,6 +8,11 @@ import type { IncomingMessage } from 'node:http';
 import type { IPty } from 'node-pty';
 import { WebSocketServer, WebSocket } from 'ws';
 
+import {
+  isProjectSpaceAuthRequired,
+  readAuthSessionFromUrl,
+  runWithAuthSession
+} from './local-auth-store';
 import type { MachineRecord, ProjectSpaceBackend } from '../src/shared/project-space-api';
 
 interface TerminalClientMessage {
@@ -181,6 +186,18 @@ export function createMachineTerminalUpgradeHandler(backend: ProjectSpaceBackend
     socket.on('message', queueMessage);
 
     try {
+      const authSession = readAuthSessionFromUrl(url);
+
+      if (isProjectSpaceAuthRequired() && !authSession) {
+        sendJson(socket, {
+          data: 'Login required.\r\n',
+          type: 'output'
+        });
+        socket.close();
+        return;
+      }
+
+      await runWithAuthSession(authSession, async () => {
       const overview = await backend.getConnectorOverview();
       const machine = overview.machines.find((entry) => entry.id === machineId);
 
@@ -209,6 +226,7 @@ export function createMachineTerminalUpgradeHandler(backend: ProjectSpaceBackend
       for (const message of queuedMessages) {
         applyTerminalMessage(pty, parseMessage(message));
       }
+      });
     } catch (error) {
       socket.off('message', queueMessage);
       sendJson(socket, {

--- a/server/project-space-http.ts
+++ b/server/project-space-http.ts
@@ -5,10 +5,21 @@ import { extname, join, normalize, resolve } from 'node:path';
 import { createLocalProjectSpaceBackend } from './local-project-space-backend';
 import { registerConnectorProjectRegistry } from './connector-hub';
 import { createMachineTerminalUpgradeHandler } from './machine-terminal-websocket';
+import {
+  getProjectSpaceAuthSessionResult,
+  isProjectSpaceAuthRequired,
+  pollProjectSpaceAuthDeviceFlow,
+  readAuthSessionFromRequest,
+  readAuthTokenFromRequest,
+  revokeProjectSpaceAuthSession,
+  runWithAuthSession,
+  startProjectSpaceAuthDeviceFlow
+} from './local-auth-store';
 import type {
   ConnectorProjectRegistryResult,
   OpenPathInAppRequest,
   CodexOpenRequest,
+  ProjectSpaceAuthDevicePollRequest,
   GitHubOAuthDevicePollRequest,
   MachineTerminalCommandRequest,
   ProjectBackupRequest,
@@ -44,7 +55,7 @@ const contentTypes: Record<string, string> = {
 
 function writeJson(response: ServerResponse, statusCode: number, payload: unknown) {
   response.writeHead(statusCode, {
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
     'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
     'Access-Control-Allow-Private-Network': 'true',
     'Access-Control-Allow-Origin': '*',
@@ -55,7 +66,7 @@ function writeJson(response: ServerResponse, statusCode: number, payload: unknow
 
 function writeEmpty(response: ServerResponse, statusCode = 204) {
   response.writeHead(statusCode, {
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
     'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
     'Access-Control-Allow-Private-Network': 'true',
     'Access-Control-Allow-Origin': '*'
@@ -97,6 +108,40 @@ function createApiHandler(backend: ProjectSpaceBackend) {
         return true;
       }
 
+      if (request.method === 'GET' && url.pathname === '/api/auth/session') {
+        writeJson(
+          response,
+          200,
+          getProjectSpaceAuthSessionResult(readAuthTokenFromRequest(request))
+        );
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/auth/github/device/start') {
+        writeJson(response, 200, await startProjectSpaceAuthDeviceFlow());
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/auth/github/device/poll') {
+        const payload = await readJson<ProjectSpaceAuthDevicePollRequest>(request);
+        writeJson(response, 200, await pollProjectSpaceAuthDeviceFlow(payload));
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/auth/logout') {
+        revokeProjectSpaceAuthSession(readAuthTokenFromRequest(request));
+        writeJson(response, 200, { ok: true });
+        return true;
+      }
+
+      const authSession = readAuthSessionFromRequest(request);
+
+      if (isProjectSpaceAuthRequired() && !authSession) {
+        writeJson(response, 401, { error: 'Login required.' });
+        return true;
+      }
+
+      return await runWithAuthSession(authSession, async () => {
       if (request.method === 'GET' && url.pathname === '/api/launcher/apps') {
         writeJson(response, 200, await backend.loadLauncherApps());
         return true;
@@ -336,6 +381,7 @@ function createApiHandler(backend: ProjectSpaceBackend) {
       }
 
       return false;
+      });
     } catch (error) {
       writeJson(response, 500, {
         error: error instanceof Error ? error.message : 'Unexpected backend error.'

--- a/server/web-server.ts
+++ b/server/web-server.ts
@@ -17,6 +17,9 @@ Usage:
 Environment:
   PROJECT_SPACE_HOST  Host to bind. Defaults to 127.0.0.1.
   PROJECT_SPACE_PORT  Port to bind. Defaults to 4173.
+  GITHUB_OAUTH_CLIENT_ID  GitHub OAuth app client ID for login.
+  PROJECT_SPACE_ALLOWED_GITHUB_LOGINS  Optional comma-separated GitHub login allowlist.
+  PROJECT_SPACE_AUTH_DISABLED=1  Disable login protection for trusted local debugging only.
 
 After starting the connector, open:
   https://project-space-mu.vercel.app

--- a/src/api/project-space-client.ts
+++ b/src/api/project-space-client.ts
@@ -20,6 +20,10 @@ import type {
   OpenPathInAppRequest,
   OpenPathInAppResult,
   PlatformOverviewResult,
+  ProjectSpaceAuthDevicePollRequest,
+  ProjectSpaceAuthDevicePollResult,
+  ProjectSpaceAuthDeviceStartResult,
+  ProjectSpaceAuthSessionResult,
   ProjectBackupRequest,
   ConnectorProjectRegistryResult,
   ProjectCliCommandRequest,
@@ -40,6 +44,29 @@ import type {
   ToolLaunchRequest,
   ToolLaunchResult
 } from '@/shared/project-space-api';
+
+const authTokenStorageKey = 'project-space.session-token';
+
+export function getProjectSpaceAuthToken() {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.localStorage.getItem(authTokenStorageKey) ?? '';
+}
+
+export function setProjectSpaceAuthToken(token: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (token) {
+    window.localStorage.setItem(authTokenStorageKey, token);
+    return;
+  }
+
+  window.localStorage.removeItem(authTokenStorageKey);
+}
 
 function resolveApiBaseUrl() {
   const explicitBaseUrl = import.meta.env.VITE_PROJECT_SPACE_API_BASE_URL;
@@ -80,9 +107,12 @@ class HttpProjectSpaceClient implements ProjectSpaceBackend {
   private readonly baseUrl = resolveApiBaseUrl();
 
   private request<T>(path: string, init?: RequestInit) {
+    const token = getProjectSpaceAuthToken();
+
     return fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
         ...init?.headers
       }
@@ -91,6 +121,32 @@ class HttpProjectSpaceClient implements ProjectSpaceBackend {
 
   getAppMeta(): Promise<AppMeta> {
     return this.request('/api/app/meta');
+  }
+
+  getAuthSession(): Promise<ProjectSpaceAuthSessionResult> {
+    return this.request('/api/auth/session');
+  }
+
+  startProjectSpaceLogin(): Promise<ProjectSpaceAuthDeviceStartResult> {
+    return this.request('/api/auth/github/device/start', {
+      method: 'POST'
+    });
+  }
+
+  pollProjectSpaceLogin(
+    request: ProjectSpaceAuthDevicePollRequest
+  ): Promise<ProjectSpaceAuthDevicePollResult> {
+    return this.request('/api/auth/github/device/poll', {
+      body: JSON.stringify(request),
+      method: 'POST'
+    });
+  }
+
+  async logout(): Promise<void> {
+    await this.request('/api/auth/logout', {
+      method: 'POST'
+    }).catch(() => undefined);
+    setProjectSpaceAuthToken('');
   }
 
   getCodexStatus(): Promise<CodexStatusResult> {

--- a/src/features/project-desktop/components/project-desktop-shell.tsx
+++ b/src/features/project-desktop/components/project-desktop-shell.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from 'react';
-import { FolderKanban, House, Server } from 'lucide-react';
+import { FolderKanban, Github, House, LogIn, Server } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button, Surface, Text } from '@/app/dotnaos-ui';
+import {
+  projectSpaceClient,
+  setProjectSpaceAuthToken
+} from '@/api/project-space-client';
+import type {
+  ProjectSpaceAuthDeviceStartResult,
+  ProjectSpaceAuthSessionResult
+} from '@/shared/project-space-api';
 import { useProjectDesktop } from '../hooks/use-project-desktop';
 import type { ProjectMainView } from '../hooks/use-project-desktop';
 import { useResizableSidebar } from '../hooks/use-resizable-sidebar';
@@ -91,7 +100,128 @@ function MobileTabBar({
   );
 }
 
-export function ProjectDesktopShell() {
+function ProjectSpaceLoginScreen({
+  onAuthenticated
+}: {
+  onAuthenticated(session: ProjectSpaceAuthSessionResult): void;
+}) {
+  const [flow, setFlow] = useState<ProjectSpaceAuthDeviceStartResult | null>(null);
+  const [message, setMessage] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+
+  async function startLogin() {
+    setIsBusy(true);
+    setMessage('');
+
+    try {
+      const nextFlow = await projectSpaceClient.startProjectSpaceLogin();
+      setFlow(nextFlow);
+
+      if (nextFlow.status !== 'pending') {
+        setMessage(nextFlow.message ?? 'Could not start GitHub login.');
+      }
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not start GitHub login.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function finishLogin() {
+    if (!flow?.deviceCode) {
+      return;
+    }
+
+    setIsBusy(true);
+    setMessage('');
+
+    try {
+      const result = await projectSpaceClient.pollProjectSpaceLogin({
+        deviceCode: flow.deviceCode
+      });
+
+      if (result.status === 'connected' && result.sessionToken) {
+        setProjectSpaceAuthToken(result.sessionToken);
+        onAuthenticated({
+          authenticated: true,
+          authRequired: true,
+          expiresAt: result.expiresAt,
+          user: result.user
+        });
+        return;
+      }
+
+      setMessage(result.message ?? `GitHub login is ${result.status}.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not finish GitHub login.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-app-canvas px-6 text-neutral-100">
+      <Surface
+        variant="secondary"
+        className="flex w-full max-w-md flex-col gap-6 rounded-lg border-neutral-800 p-6"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-lg bg-neutral-100 text-neutral-950">
+            <Github className="size-5" strokeWidth={2} />
+          </div>
+          <div className="min-w-0">
+            <Text as="h1" className="text-xl font-semibold text-neutral-50">
+              Sign in to Project Space
+            </Text>
+            <Text as="p" className="mt-1 text-sm text-neutral-400">
+              GitHub login is required before this connector exposes local machines.
+            </Text>
+          </div>
+        </div>
+
+        {flow?.status === 'pending' ? (
+          <div className="flex flex-col gap-4">
+            <div className="rounded-lg bg-neutral-900 px-4 py-3">
+              <Text as="p" className="text-sm text-neutral-400">
+                Enter this code on GitHub:
+              </Text>
+              <Text as="p" className="mt-2 font-mono text-2xl font-semibold tracking-wide text-neutral-50">
+                {flow.userCode}
+              </Text>
+            </div>
+            {flow.verificationUri ? (
+              <a
+                className="text-sm font-medium text-neutral-100 underline decoration-neutral-600 underline-offset-4 hover:text-white"
+                href={flow.verificationUri}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open GitHub device login
+              </a>
+            ) : null}
+            <Button onPress={finishLogin} isDisabled={isBusy}>
+              <LogIn className="size-4" />
+              Check login
+            </Button>
+          </div>
+        ) : (
+          <Button onPress={startLogin} isDisabled={isBusy}>
+            <Github className="size-4" />
+            Sign in with GitHub
+          </Button>
+        )}
+
+        {message ? (
+          <Text as="p" className="text-sm text-amber-300">
+            {message}
+          </Text>
+        ) : null}
+      </Surface>
+    </div>
+  );
+}
+
+function AuthenticatedProjectDesktopShell() {
   const desktop = useProjectDesktop();
   const [isCompact, setIsCompact] = useState(isCompactViewport);
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => !isCompactViewport());
@@ -307,4 +437,48 @@ export function ProjectDesktopShell() {
       ) : null}
     </div>
   );
+}
+
+export function ProjectDesktopShell() {
+  const [session, setSession] = useState<ProjectSpaceAuthSessionResult | null>(null);
+  const [isCheckingSession, setIsCheckingSession] = useState(true);
+
+  useEffect(() => {
+    let canceled = false;
+
+    projectSpaceClient
+      .getAuthSession()
+      .then((nextSession) => {
+        if (!canceled) {
+          setSession(nextSession);
+        }
+      })
+      .catch(() => {
+        if (!canceled) {
+          setSession({
+            authenticated: false,
+            authRequired: true
+          });
+        }
+      })
+      .finally(() => {
+        if (!canceled) {
+          setIsCheckingSession(false);
+        }
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, []);
+
+  if (isCheckingSession) {
+    return <div className="min-h-screen bg-app-canvas" />;
+  }
+
+  if (session?.authRequired && !session.authenticated) {
+    return <ProjectSpaceLoginScreen onAuthenticated={setSession} />;
+  }
+
+  return <AuthenticatedProjectDesktopShell />;
 }

--- a/src/features/project-desktop/components/project-main-panel.tsx
+++ b/src/features/project-desktop/components/project-main-panel.tsx
@@ -22,7 +22,7 @@ import {
 import { WTerm } from '@wterm/dom';
 import '@wterm/dom/css';
 import { Button, Card, Chip, Surface, Text } from '@/app/dotnaos-ui';
-import { projectSpaceClient } from '@/api/project-space-client';
+import { getProjectSpaceAuthToken, projectSpaceClient } from '@/api/project-space-client';
 import { OpenTargetDropdown } from './open-target-dropdown';
 import { ProjectCliCommandPanel } from './project-cli-command-panel';
 import { ProjectHomeOverview } from './project-home-overview';
@@ -377,9 +377,14 @@ const MachineTerminalSession = memo(function MachineTerminalSession({
           new URL(window.location.href).searchParams.get('projectSpaceApi') ||
           window.location.origin;
         const url = new URL(`/api/machines/${encodeURIComponent(machineId)}/terminal`, baseUrl);
+        const sessionToken = getProjectSpaceAuthToken();
+
         url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
         url.searchParams.set('cols', String(cols));
         url.searchParams.set('rows', String(rows));
+        if (sessionToken) {
+          url.searchParams.set('session', sessionToken);
+        }
         const socket = new WebSocket(url);
         socketRef.current = socket;
 

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -198,6 +198,41 @@ export interface GitActionResult {
   stderr?: string;
 }
 
+export interface ProjectSpaceAuthUser {
+  login: string;
+  role: 'owner' | 'user';
+}
+
+export interface ProjectSpaceAuthSessionResult {
+  authenticated: boolean;
+  authRequired: boolean;
+  expiresAt?: string;
+  user?: ProjectSpaceAuthUser;
+}
+
+export interface ProjectSpaceAuthDeviceStartResult {
+  deviceCode?: string;
+  expiresAt?: string;
+  intervalSeconds?: number;
+  message?: string;
+  status: 'pending' | 'not-configured' | 'error';
+  userCode?: string;
+  verificationUri?: string;
+}
+
+export interface ProjectSpaceAuthDevicePollRequest {
+  deviceCode: string;
+}
+
+export interface ProjectSpaceAuthDevicePollResult {
+  expiresAt?: string;
+  intervalSeconds?: number;
+  message?: string;
+  sessionToken?: string;
+  status: 'pending' | 'connected' | 'expired' | 'denied' | 'error';
+  user?: ProjectSpaceAuthUser;
+}
+
 export type GitHubAuthSource = 'stored-oauth' | 'environment';
 export type GitHubCatalogStatus = 'connected' | 'auth-required' | 'not-configured' | 'error';
 export type GitHubProjectConfigStatus = 'complete' | 'partial' | 'missing' | 'unknown';


### PR DESCRIPTION
## Summary
- add Project Space login gate backed by GitHub device OAuth
- store local users/sessions in a connector auth database under ~/.project-space
- require a valid session for connector APIs and live machine terminal WebSockets
- use the signed-in user's GitHub token for repository data instead of silently falling back to a global account

## Verification
- bun run check
- pnpm build
- go test ./...
- curl: /api/connectors/overview returns 401 without a session
- websocket: /api/machines/os-macbook/terminal returns Login required without a session
- Browser: root route shows the GitHub login gate before loading Project Space