### PR TITLE
Install build tools for web Docker deps

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,9 @@
 FROM oven/bun:1 AS deps
 
 WORKDIR /workspace
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential python3 \
+  && rm -rf /var/lib/apt/lists/*
 COPY package.json ./
 RUN bun install
 


### PR DESCRIPTION
## Summary
- install Python and build-essential in the web Docker dependency stage so node-pty can compile during deploy

## Verification
- bun run check
- bun run build
- go test ./...
- docker build -f deploy/Dockerfile -t project-space-web:deploy-smoke .