### PR TITLE
Read deploy env file explicitly

### DIFF
--- a/cmd/project/deploy.go
+++ b/cmd/project/deploy.go
@@ -425,14 +425,14 @@ func deploySteps(project deployProject, options deployOptions) []string {
 
 func composeUpStep(project deployProject, options deployOptions) string {
 	return fmt.Sprintf(
-		"set -e; cd %s; cat > .env <<'PROJECT_SPACE_ENV'\n%s\nPROJECT_SPACE_ENV\ndocker compose -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build",
+		"set -e; cd %s; cat > .env <<'PROJECT_SPACE_ENV'\n%s\nPROJECT_SPACE_ENV\ndocker compose --env-file .env -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build",
 		shellQuote(project.RemotePath),
 		deployEnvFileContent(options, false),
 	)
 }
 
 func composeStatusStep(project deployProject, options deployOptions) string {
-	return fmt.Sprintf("set -e; cd %s; docker compose -f deploy/compose.yml -f deploy/ingress.labels.yml ps", shellQuote(project.RemotePath))
+	return fmt.Sprintf("set -e; cd %s; docker compose --env-file .env -f deploy/compose.yml -f deploy/ingress.labels.yml ps", shellQuote(project.RemotePath))
 }
 
 func deployStatusEnv(options deployOptions) string {
@@ -485,9 +485,9 @@ func secretSourceLabel(source string) string {
 }
 
 func deployComposeScript(project deployProject, options deployOptions, up bool) string {
-	command := "docker compose -f deploy/compose.yml -f deploy/ingress.labels.yml ps"
+	command := "docker compose --env-file .env -f deploy/compose.yml -f deploy/ingress.labels.yml ps"
 	if up {
-		command = "docker compose -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build"
+		command = "docker compose --env-file .env -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build"
 	}
 	return strings.Join([]string{
 		"set -e",

--- a/cmd/project/deploy_test.go
+++ b/cmd/project/deploy_test.go
@@ -74,7 +74,7 @@ func TestDeployComposeScriptUsesSecretValuesOnlyAtRuntime(t *testing.T) {
 		"CLERK_PUBLISHABLE_KEY=clerk-publishable-value",
 		"VITE_CLERK_PUBLISHABLE_KEY=clerk-publishable-value",
 		"CLERK_SECRET_KEY=clerk-secret-value",
-		"docker compose -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build",
+		"docker compose --env-file .env -f deploy/compose.yml -f deploy/ingress.labels.yml up -d --build",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("runtime deploy script missing %q:\n%s", want, script)


### PR DESCRIPTION
## Summary
- pass --env-file .env to docker compose during deploy and status checks
- keep the remote .env file as the source for deploy-time variables

## Verification
- go test ./...
- bun run check
- git diff --check
- ./bin/project deploy --dry-run --host deploy@100.84.238.75 --path /opt/platform/apps/project-space --branch main --domain projects.os-home.net --api-domain projects-api.os-home.net