### PR TITLE
Enable terminal SSH metadata for connector machines

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,6 +20,9 @@ RUN bun run build
 FROM oven/bun:1 AS runner
 
 WORKDIR /workspace
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssh-client \
+  && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
 ENV PROJECT_SPACE_HOST=0.0.0.0
 ENV PROJECT_SPACE_PORT=4173

--- a/server/connector-hub.ts
+++ b/server/connector-hub.ts
@@ -88,9 +88,10 @@ export function getRegisteredConnectorMachines(): MachineRecord[] {
       status: 'online'
     },
     id: registry.connector.machineId,
-    kind: 'connector',
+    kind: registry.connector.kind ?? 'connector',
     name: registry.connector.machineName,
-    network: {},
+    network: registry.connector.network ?? {},
+    primaryUser: registry.connector.primaryUser,
     roles: ['connector'],
     sourcePath: 'connector-hub'
   }));

--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -603,9 +603,25 @@ export function createLocalProjectSpaceBackend(
         checkedAt: new Date().toISOString(),
         connector: {
           battery: localMachine?.battery,
+          kind: process.env.PROJECT_CONNECTOR_MACHINE_KIND ?? localMachine?.kind,
           machineId: localMachine?.id ?? machineName,
           machineName,
+          network: {
+            ...localMachine?.network,
+            localName:
+              process.env.PROJECT_CONNECTOR_SSH_HOST ??
+              localMachine?.network.localName,
+            sshUser:
+              process.env.PROJECT_CONNECTOR_SSH_USER ??
+              localMachine?.network.sshUser,
+            tailscaleIp:
+              process.env.PROJECT_CONNECTOR_SSH_HOST ??
+              localMachine?.network.tailscaleIp
+          },
           origin: connector.connectorOrigin,
+          primaryUser:
+            process.env.PROJECT_CONNECTOR_SSH_USER ??
+            localMachine?.primaryUser,
           serviceName: process.env.PROJECT_CONNECTOR_SERVICE_NAME ?? 'project-space-connector'
         },
         discovery

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -404,9 +404,12 @@ export interface ConnectorProjectRegistryResult {
   checkedAt: string;
   connector: {
     battery?: MachineBatteryRecord;
+    kind?: string;
     machineId: string;
     machineName: string;
+    network?: MachineRecord['network'];
     origin?: string;
+    primaryUser?: string;
     serviceName?: string;
   };
   discovery: ProjectDiscoveryResult;


### PR DESCRIPTION
## Summary
- pass connector machine type, SSH target, and SSH user through the registry
- install openssh-client in the web runtime image so machine terminals can open SSH sessions

## Verification
- bun run check
- go test ./...
- git diff --check
- VITE_CLERK_PUBLISHABLE_KEY=... bun run build
- docker build ... && docker run --entrypoint ssh ... -V