### PR TITLE
Mount persistent SSH config into web container

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -19,6 +19,8 @@ services:
       PROJECT_CONNECTOR_SERVICE_NAME: project-space-web
     image: project-space-web:local
     restart: unless-stopped
+    volumes:
+      - ./ssh:/root/.ssh:ro
 
   docs:
     build:


### PR DESCRIPTION
## Summary
- mount ./ssh into the web container as /root/.ssh read-only so terminal SSH keys survive deploys

## Verification
- bun run check
- go test ./...
- git diff --check