### PR TITLE
Refactor Project Desktop components

### DIFF
--- a/src/features/project-desktop/components/machine-detail-view.tsx
+++ b/src/features/project-desktop/components/machine-detail-view.tsx
@@ -1,0 +1,386 @@
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  ConnectorOverviewResult,
+  MachineRecord,
+  ProjectSpaceRecord
+} from '@/shared/project-space-api';
+import { refreshProjectSpaceAuthToken } from '@/api/project-space-client';
+import { Button, Surface, Text } from '@/app/dotnaos-ui';
+import { Terminal as TerminalIcon } from 'lucide-react';
+import { WTerm } from '@wterm/dom';
+import '@wterm/dom/css';
+import {
+  isMachineConnected,
+  MachineBatteryMeter,
+  MachineConnectionIcon,
+  MachineDeviceIcon,
+  MachineOsMark
+} from './machine-visuals';
+import {
+  formatOptionalTime,
+  getProjectMachineId,
+  isVisibleProject,
+  machineSubtitle
+} from './project-main-model';
+
+function MachineDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 items-baseline justify-between gap-4 border-b border-neutral-900/70 py-2 last:border-b-0">
+      <Text className="shrink-0 text-xs font-medium text-neutral-500">{label}</Text>
+      <Text className="min-w-0 truncate text-right text-sm text-neutral-200">{value}</Text>
+    </div>
+  );
+}
+
+type MachineTerminalStatus = 'connecting' | 'connected' | 'closed' | 'error';
+
+const MachineTerminalSession = memo(function MachineTerminalSession({
+  canRun,
+  machineId,
+  onStatusChange,
+  sessionVersion
+}: {
+  canRun: boolean;
+  machineId: string;
+  onStatusChange(status: MachineTerminalStatus, message?: string): void;
+  sessionVersion: number;
+}) {
+  const terminalElementRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<WTerm | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const sizeRef = useRef({ cols: 100, rows: 28 });
+
+  useEffect(() => {
+    const element = terminalElementRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    let canceled = false;
+    const terminal = new WTerm(element, {
+      autoResize: true,
+      cols: 100,
+      cursorBlink: true,
+      onData(data) {
+        const socket = socketRef.current;
+
+        if (socket?.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ data, type: 'input' }));
+        }
+      },
+      onResize(cols, rows) {
+        sizeRef.current = { cols, rows };
+        const socket = socketRef.current;
+
+        if (socket?.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ cols, rows, type: 'resize' }));
+        }
+      },
+      rows: 28
+    });
+    terminalRef.current = terminal;
+
+    terminal
+      .init()
+      .then(async () => {
+        if (canceled) {
+          return;
+        }
+
+        if (!canRun) {
+          onStatusChange('closed');
+          return;
+        }
+
+        const { cols, rows } = sizeRef.current;
+        const baseUrl =
+          import.meta.env.VITE_PROJECT_SPACE_API_BASE_URL ||
+          new URL(window.location.href).searchParams.get('projectSpaceApi') ||
+          window.location.origin;
+        const url = new URL(`/api/machines/${encodeURIComponent(machineId)}/terminal`, baseUrl);
+        const sessionToken = await refreshProjectSpaceAuthToken();
+
+        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+        url.searchParams.set('cols', String(cols));
+        url.searchParams.set('rows', String(rows));
+        if (sessionToken) {
+          url.searchParams.set('session', sessionToken);
+        }
+        const socket = new WebSocket(url);
+        socketRef.current = socket;
+
+        onStatusChange('connecting');
+        terminal.write('\x1bc');
+
+        socket.addEventListener('open', () => {
+          if (canceled) {
+            return;
+          }
+
+          onStatusChange('connected');
+          terminal.focus();
+        });
+
+        socket.addEventListener('message', (event) => {
+          try {
+            const message = JSON.parse(String(event.data)) as {
+              data?: string;
+              exitCode?: number;
+              signal?: number;
+              type: 'output' | 'exit';
+            };
+
+            if (message.type === 'output' && typeof message.data === 'string') {
+              terminal.write(message.data);
+              return;
+            }
+
+            if (message.type === 'exit') {
+              terminal.write(
+                `\r\n[session exited: ${message.exitCode ?? message.signal ?? 'closed'}]\r\n`
+              );
+            }
+          } catch {
+            terminal.write(String(event.data));
+          }
+        });
+
+        socket.addEventListener('close', () => {
+          if (socketRef.current === socket) {
+            socketRef.current = null;
+          }
+
+          if (!canceled) {
+            onStatusChange('closed');
+          }
+        });
+
+        socket.addEventListener('error', () => {
+          if (!canceled) {
+            onStatusChange('error');
+            terminal.write('\r\n[terminal connection failed]\r\n');
+          }
+        });
+      })
+      .catch((error) => {
+        if (canceled) {
+          return;
+        }
+
+        onStatusChange(
+          'error',
+          `wterm failed to initialize: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`
+        );
+      });
+
+    return () => {
+      canceled = true;
+      socketRef.current?.close();
+      socketRef.current = null;
+      terminal.destroy();
+      if (terminalRef.current === terminal) {
+        terminalRef.current = null;
+      }
+      onStatusChange('closed');
+    };
+  }, [canRun, machineId, onStatusChange, sessionVersion]);
+
+  return <div ref={terminalElementRef} className="project-machine-terminal h-[28rem] w-full" />;
+}, (previous, next) => {
+  return (
+    previous.canRun === next.canRun &&
+    previous.machineId === next.machineId &&
+    previous.sessionVersion === next.sessionVersion
+  );
+});
+
+function MachineTerminalPanel({ machine }: { machine: MachineRecord }) {
+  const [sessionVersion, setSessionVersion] = useState(0);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [status, setStatus] = useState<MachineTerminalStatus>('closed');
+  const canRun = isMachineConnected(machine);
+  const handleStatusChange = useCallback((nextStatus: MachineTerminalStatus, message?: string) => {
+    setErrorMessage(message ?? '');
+    setStatus(nextStatus);
+  }, []);
+
+  function reconnect() {
+    setSessionVersion((current) => current + 1);
+  }
+
+  return (
+    <Surface
+      variant="tertiary"
+      className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <TerminalIcon className="size-4 text-neutral-400" />
+          <Text className="text-sm font-semibold text-neutral-100">Terminal</Text>
+        </div>
+        <Button size="sm" isDisabled={!canRun || status === 'connecting'} onPress={reconnect}>
+          {status === 'connected' ? 'Reconnect' : 'Connect'}
+        </Button>
+      </div>
+
+      {!canRun ? (
+        <Text className="block text-xs text-neutral-500">
+          This machine is not connected, so no shell is available right now.
+        </Text>
+      ) : null}
+      <div className="overflow-hidden rounded-lg border border-neutral-800 bg-black">
+        <MachineTerminalSession
+          canRun={canRun}
+          machineId={machine.id}
+          onStatusChange={handleStatusChange}
+          sessionVersion={sessionVersion}
+        />
+      </div>
+      <Text className="mt-2 block text-xs text-neutral-600">
+        {status === 'connected'
+          ? 'Live shell connected.'
+          : status === 'connecting'
+            ? 'Connecting shell...'
+            : status === 'error'
+              ? errorMessage || 'Terminal connection failed.'
+              : 'Terminal disconnected.'}
+      </Text>
+    </Surface>
+  );
+}
+
+export function MachineDetailView({
+  connector,
+  machine,
+  machineId,
+  onOpenMachines,
+  onSelectProject,
+  projects
+}: {
+  connector: ConnectorOverviewResult;
+  machine?: MachineRecord;
+  machineId: string;
+  onOpenMachines(): void;
+  onSelectProject(projectId: string): void;
+  projects: ProjectSpaceRecord[];
+}) {
+  const localMachineId =
+    connector.machines.find((entry) => entry.connector.status === 'local')?.id ??
+    connector.machines[0]?.id ??
+    'local';
+  const machineProjects = machine
+    ? projects
+        .filter(isVisibleProject)
+        .filter((project) => project.kind !== 'github')
+        .filter((project) => getProjectMachineId(project, localMachineId) === machine.id)
+        .sort((left, right) => left.name.localeCompare(right.name))
+    : [];
+
+  if (!machine) {
+    return (
+      <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col justify-center gap-4">
+        <Text className="block text-2xl font-semibold text-neutral-100">Machine not found</Text>
+        <Text className="block text-sm text-neutral-500">
+          {machineId || 'This machine'} is not currently in the connector registry.
+        </Text>
+        <Button className="w-fit" variant="secondary" onPress={onOpenMachines}>
+          Back to machines
+        </Button>
+      </div>
+    );
+  }
+
+  const origin =
+    machine.connector.origin ?? machine.network.tailscaleIp ?? machine.connector.installCommand;
+
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-5">
+      <section className="border-b border-neutral-800/70 pb-5">
+        <div className="flex min-w-0 flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <MachineDeviceIcon machine={machine} />
+              <Text className="truncate text-2xl font-semibold text-neutral-50">
+                {machine.name}
+              </Text>
+              <MachineOsMark machine={machine} />
+            </div>
+            <Text className="mt-1 block text-sm text-neutral-500">
+              {machineSubtitle(machine) || 'machine'}
+            </Text>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-3">
+            <MachineConnectionIcon machine={machine} />
+            <MachineBatteryMeter machine={machine} />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <Surface
+          variant="tertiary"
+          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+        >
+          <Text className="mb-3 block text-sm font-semibold text-neutral-100">Connection</Text>
+          <MachineDetailRow label="Status" value={machine.connector.status} />
+          <MachineDetailRow label="Service" value={machine.connector.serviceName ?? 'unknown'} />
+          <MachineDetailRow label="Last seen" value={formatOptionalTime(machine.connector.lastSeen)} />
+          <MachineDetailRow label="Origin" value={origin ?? 'unknown'} />
+        </Surface>
+
+        <Surface
+          variant="tertiary"
+          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+        >
+          <Text className="mb-3 block text-sm font-semibold text-neutral-100">System</Text>
+          <MachineDetailRow label="OS" value={[machine.os?.family, machine.os?.version].filter(Boolean).join(' ') || 'unknown'} />
+          <MachineDetailRow label="Device" value={machine.kind || 'unknown'} />
+          <MachineDetailRow label="Profile" value={machine.profile ?? 'unknown'} />
+          <MachineDetailRow label="User" value={machine.primaryUser ?? machine.network.sshUser ?? 'unknown'} />
+        </Surface>
+      </section>
+
+      <MachineTerminalPanel machine={machine} />
+
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <Text className="text-sm font-semibold text-neutral-100">Projects on this machine</Text>
+          <Text className="text-xs text-neutral-500">{machineProjects.length}</Text>
+        </div>
+
+        {machineProjects.length > 0 ? (
+          <div className="flex flex-col divide-y divide-neutral-900/80">
+            {machineProjects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                title={project.rootPath}
+                onClick={() => onSelectProject(project.id)}
+                className="flex min-w-0 items-center justify-between gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
+              >
+                <span className="min-w-0">
+                  <Text className="block truncate text-sm font-medium text-neutral-100">
+                    {project.name}
+                  </Text>
+                  <Text className="block truncate font-mono text-xs text-neutral-500">
+                    {project.rootPath}
+                  </Text>
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-neutral-950/45 px-4 py-6">
+            <Text className="text-sm text-neutral-500">
+              No local projects reported by this machine yet.
+            </Text>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/project-desktop-shell.tsx
+++ b/src/features/project-desktop/components/project-desktop-shell.tsx
@@ -331,6 +331,7 @@ function AuthenticatedProjectDesktopShell() {
           onOpenMachines={desktop.openMachines}
           onOpenMachine={desktop.openMachine}
           onOpenProjects={desktop.openProjects}
+          onOpenRoot={desktop.openRoot}
           onOpenSelectedTarget={desktop.openSelectedTargetInApp}
           onRefreshConnectorOverview={desktop.refreshConnectorOverview}
           onRefreshGitHubCatalog={desktop.refreshGitHubCatalog}

--- a/src/features/project-desktop/components/project-home-overview-model.ts
+++ b/src/features/project-desktop/components/project-home-overview-model.ts
@@ -1,0 +1,210 @@
+import type {
+  FullstackTemplateStatus,
+  GitHubCatalogRepository,
+  GitHubProjectConfigStatus,
+  ProjectSpaceRecord,
+  ProjectWorktreeRecord
+} from '@/shared/project-space-api';
+
+export interface LocalMatch {
+  machineId: string;
+  project: ProjectSpaceRecord;
+}
+
+export interface MatrixRow {
+  id: string;
+  isLocalOnly: boolean;
+  localMatches: LocalMatch[];
+  repo?: GitHubCatalogRepository;
+  title: string;
+}
+
+export interface BranchChipRecord {
+  isBase: boolean;
+  name: string;
+}
+
+export const templateStatusLabels: Record<FullstackTemplateStatus, string> = {
+  implemented: 'ok',
+  partial: 'partial',
+  'not-detected': 'missing',
+  'template-source': 'template'
+};
+
+export function getMachineId(project: ProjectSpaceRecord) {
+  return project.id.includes(':') ? project.id.slice(0, project.id.indexOf(':')) : 'local';
+}
+
+export function getProjectMachineId(project: ProjectSpaceRecord, localMachineId: string) {
+  const machineId = getMachineId(project);
+  return machineId === 'local' ? localMachineId : machineId;
+}
+
+export function getTemplateStatus(project: ProjectSpaceRecord): FullstackTemplateStatus {
+  return project.fullstackTemplate?.status ?? 'not-detected';
+}
+
+export function basename(path: string) {
+  return path.split('/').filter(Boolean).at(-1) ?? path;
+}
+
+export function isVisibleLocalProject(project: ProjectSpaceRecord) {
+  if (project.kind === 'github') {
+    return false;
+  }
+
+  const projectFolder = basename(project.rootPath);
+
+  return !projectFolder.startsWith('.') && !projectFolder.endsWith('.worktrees');
+}
+
+export function normalizeKey(value: string) {
+  return value.trim().replace(/^@/, '').toLowerCase();
+}
+
+export function matchesQuery(values: Array<string | undefined>, query: string) {
+  const normalizedQuery = normalizeKey(query);
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return values.some((value) => normalizeKey(value ?? '').includes(normalizedQuery));
+}
+
+function projectKeys(project: ProjectSpaceRecord) {
+  const name = normalizeKey(project.name);
+  const rootName = normalizeKey(basename(project.rootPath));
+  const keys = new Set([name, rootName]);
+
+  if (name.includes('/')) {
+    keys.add(name.split('/').at(-1) ?? name);
+  }
+
+  return keys;
+}
+
+export function projectMatchesRepo(project: ProjectSpaceRecord, repo: GitHubCatalogRepository) {
+  const keys = projectKeys(project);
+  const fullName = normalizeKey(repo.fullName);
+  const name = normalizeKey(repo.name);
+
+  return keys.has(fullName) || keys.has(name);
+}
+
+export function isBaseBranchName(branchName: string, defaultBranch?: string) {
+  const normalizedBranch = normalizeKey(branchName);
+  const normalizedDefault = defaultBranch ? normalizeKey(defaultBranch) : '';
+
+  return (
+    (normalizedDefault && normalizedBranch === normalizedDefault) ||
+    normalizedBranch === 'main' ||
+    normalizedBranch === 'master'
+  );
+}
+
+export function branchesFromWorktrees(
+  worktrees: ProjectWorktreeRecord[],
+  defaultBranch?: string
+): BranchChipRecord[] {
+  const branches = new Map<string, BranchChipRecord>();
+
+  for (const worktree of worktrees) {
+    const branchName = worktree.branchName?.trim();
+
+    if (!branchName) {
+      continue;
+    }
+
+    branches.set(branchName, {
+      isBase: isBaseBranchName(branchName, defaultBranch),
+      name: branchName
+    });
+  }
+
+  return Array.from(branches.values()).sort((left, right) => {
+    if (left.isBase !== right.isBase) {
+      return left.isBase ? -1 : 1;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function mergeBranchChips(
+  defaultBranch: string | undefined,
+  branchGroups: BranchChipRecord[][]
+) {
+  const branches = new Map<string, BranchChipRecord>();
+
+  if (defaultBranch) {
+    branches.set(defaultBranch, {
+      isBase: true,
+      name: defaultBranch
+    });
+  }
+
+  for (const group of branchGroups) {
+    for (const branch of group) {
+      const existing = branches.get(branch.name);
+
+      branches.set(branch.name, {
+        isBase: existing?.isBase || branch.isBase || isBaseBranchName(branch.name, defaultBranch),
+        name: branch.name
+      });
+    }
+  }
+
+  return Array.from(branches.values()).sort((left, right) => {
+    if (left.isBase !== right.isBase) {
+      return left.isBase ? -1 : 1;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function configChipClass(status: GitHubProjectConfigStatus | FullstackTemplateStatus) {
+  if (status === 'complete' || status === 'implemented' || status === 'template-source') {
+    return 'text-emerald-300';
+  }
+
+  if (status === 'partial') {
+    return 'text-amber-300';
+  }
+
+  return 'text-neutral-500';
+}
+
+export function formatLastSeen(value?: string) {
+  if (!value) {
+    return 'not seen';
+  }
+
+  const timestamp = Date.parse(value);
+
+  if (!Number.isFinite(timestamp)) {
+    return value;
+  }
+
+  const minutes = Math.max(0, Math.round((Date.now() - timestamp) / 60_000));
+
+  if (minutes < 1) {
+    return 'now';
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  return hours < 24 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+}
+
+export function installScriptUrl() {
+  if (typeof window === 'undefined') {
+    return '/connector/install.sh';
+  }
+
+  return `${window.location.origin}/connector/install.sh`;
+}

--- a/src/features/project-desktop/components/project-home-overview-widgets.tsx
+++ b/src/features/project-desktop/components/project-home-overview-widgets.tsx
@@ -1,0 +1,344 @@
+import type {
+  GitHubCatalogRepository,
+  GitHubCatalogResult,
+  GitHubOAuthDeviceStartResult,
+  MachineRecord
+} from '@/shared/project-space-api';
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  Github,
+  Info,
+  Terminal,
+  X
+} from 'lucide-react';
+import {
+  Button,
+  SearchField,
+  SearchFieldClearButton,
+  SearchFieldGroup,
+  SearchFieldInput,
+  SearchFieldSearchIcon,
+  Text,
+  Tooltip
+} from '@/app/dotnaos-ui';
+import {
+  formatLastSeen,
+  type BranchChipRecord,
+  type MatrixRow
+} from './project-home-overview-model';
+
+function DetailRow({ label, mono, value }: { label: string; mono?: boolean; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="shrink-0 text-[10px] font-medium text-neutral-500">{label}</span>
+      <span
+        className={[
+          'min-w-0 truncate text-right text-neutral-200',
+          mono ? 'font-mono text-[11px]' : 'text-xs'
+        ].join(' ')}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function MachineDetailsTooltip({
+  machine,
+  projectCount
+}: {
+  machine: MachineRecord;
+  projectCount: number;
+}) {
+  const origin =
+    machine.connector.origin ?? machine.network.tailscaleIp ?? machine.connector.installCommand;
+
+  return (
+    <Tooltip delay={150}>
+      <Tooltip.Trigger className="inline-flex">
+        <span
+          aria-label={`${machine.name} details`}
+          className="inline-flex size-5 items-center justify-center rounded-full text-neutral-600 transition hover:text-neutral-300"
+        >
+          <Info className="size-3.5" strokeWidth={1.8} />
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content className="w-56 space-y-1.5">
+        {machine.connector.serviceName ? (
+          <DetailRow label="Service" value={machine.connector.serviceName} />
+        ) : null}
+        <DetailRow label="Status" value={machine.connector.status} />
+        <DetailRow label="Projects" value={String(projectCount)} />
+        <DetailRow label="Last seen" value={formatLastSeen(machine.connector.lastSeen)} />
+        {origin ? <DetailRow label="Origin" mono value={origin} /> : null}
+      </Tooltip.Content>
+    </Tooltip>
+  );
+}
+
+export function BranchChips({ branches }: { branches: BranchChipRecord[] }) {
+  if (branches.length === 0) {
+    return null;
+  }
+
+  const visibleBranches = branches.slice(0, 3);
+  const hiddenCount = branches.length - visibleBranches.length;
+
+  return (
+    <div
+      aria-label="Branches"
+      className="flex max-w-[17rem] shrink-0 items-center gap-1 overflow-x-auto"
+    >
+      {visibleBranches.map((branch) => (
+        <span
+          key={branch.name}
+          title={branch.name}
+          className={[
+            'inline-flex max-w-28 shrink-0 items-center truncate rounded-full px-2 py-0.5 text-[11px] font-medium',
+            branch.isBase
+              ? 'bg-neutral-100 text-neutral-950'
+              : 'bg-neutral-800/80 text-neutral-300'
+          ].join(' ')}
+        >
+          {branch.name}
+        </span>
+      ))}
+      {hiddenCount > 0 ? (
+        <span
+          title={branches.slice(3).map((branch) => branch.name).join(', ')}
+          className="inline-flex shrink-0 rounded-full bg-neutral-900 px-2 py-0.5 text-[11px] font-medium text-neutral-500"
+        >
+          +{hiddenCount}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function MainListSearch({
+  label,
+  onChange,
+  placeholder,
+  value
+}: {
+  label: string;
+  onChange(value: string): void;
+  placeholder: string;
+  value: string;
+}) {
+  return (
+    <SearchField aria-label={label} value={value} onChange={onChange}>
+      <SearchFieldGroup className="rounded-lg bg-neutral-900/90">
+        <SearchFieldSearchIcon />
+        <SearchFieldInput className="text-sm" placeholder={placeholder} />
+        <SearchFieldClearButton />
+      </SearchFieldGroup>
+    </SearchField>
+  );
+}
+
+function projectIdForRow(row: MatrixRow) {
+  return row.localMatches[0]?.project.id ?? (row.repo ? `github:${row.repo.fullName}` : '');
+}
+
+function GitHubLinkButton({ label, repo }: { label: string; repo: GitHubCatalogRepository }) {
+  return (
+    <a
+      href={repo.url}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={`Open ${repo.fullName} on GitHub`}
+      onClick={(event) => event.stopPropagation()}
+      className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-neutral-600 transition hover:bg-neutral-900 hover:text-neutral-200"
+      title={label}
+    >
+      <ExternalLink className="size-3.5" />
+    </a>
+  );
+}
+
+export function ProjectListItem({
+  branches,
+  layout,
+  onSelectProject,
+  row
+}: {
+  branches: BranchChipRecord[];
+  layout: 'grid' | 'list';
+  onSelectProject(projectId: string): void;
+  row: MatrixRow;
+}) {
+  const projectId = projectIdForRow(row);
+
+  if (layout === 'grid') {
+    return (
+      <div
+        key={row.id}
+        className="group flex min-w-0 flex-col gap-4 rounded-lg border border-neutral-900 bg-neutral-950/45 p-4 transition hover:border-neutral-800 hover:bg-neutral-950/70"
+      >
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => projectId && onSelectProject(projectId)}
+            className="min-w-0 flex-1 text-left"
+          >
+            <Text className="block min-w-0 truncate text-sm font-semibold text-neutral-100">
+              {row.repo?.name ?? row.title}
+            </Text>
+            <Text className="mt-1 block truncate text-xs text-neutral-500">
+              {row.repo?.owner ?? 'Local'}
+            </Text>
+          </button>
+          {row.repo ? <GitHubLinkButton repo={row.repo} label="Open on GitHub" /> : null}
+        </div>
+        <BranchChips branches={branches} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key={row.id}
+      className="flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 transition hover:bg-neutral-900/40"
+    >
+      <button
+        type="button"
+        onClick={() => projectId && onSelectProject(projectId)}
+        className="min-w-0 flex-1 text-left"
+      >
+        <Text className="block min-w-0 truncate text-sm font-medium text-neutral-100">
+          {row.repo?.name ?? row.title}
+        </Text>
+      </button>
+      <BranchChips branches={branches} />
+      {row.repo ? <GitHubLinkButton repo={row.repo} label="Open on GitHub" /> : null}
+    </div>
+  );
+}
+
+export function GitHubConnectPanel({
+  flow,
+  githubCatalog,
+  isConnecting,
+  onConnect,
+  onPoll
+}: {
+  flow?: GitHubOAuthDeviceStartResult;
+  githubCatalog: GitHubCatalogResult;
+  isConnecting: boolean;
+  onConnect(): void;
+  onPoll(): void;
+}) {
+  if (githubCatalog.status === 'connected') {
+    return null;
+  }
+
+  return (
+    <div className="mb-4 rounded-lg bg-neutral-950/60 px-4 py-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <Text className="block text-sm font-semibold text-neutral-100">Connect GitHub</Text>
+          <Text className="mt-1 block text-sm text-neutral-500">
+            {flow?.status === 'pending'
+              ? 'Enter this code on GitHub, then check the login here.'
+              : githubCatalog.message ?? 'Connect GitHub to load repositories.'}
+          </Text>
+        </div>
+        {flow?.status === 'pending' ? (
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <span className="rounded-lg bg-neutral-900 px-3 py-1.5 font-mono text-sm font-semibold text-neutral-100">
+              {flow.userCode}
+            </span>
+            {flow.verificationUri ? (
+              <a href={flow.verificationUri} target="_blank" rel="noreferrer">
+                <Button size="sm" variant="outline">
+                  <ExternalLink className="size-4" />
+                  Open GitHub
+                </Button>
+              </a>
+            ) : null}
+            <Button size="sm" isDisabled={isConnecting} onPress={onPoll}>
+              Check login
+            </Button>
+          </div>
+        ) : (
+          <Button
+            className="shrink-0"
+            size="sm"
+            isDisabled={isConnecting || githubCatalog.status === 'not-configured'}
+            onPress={onConnect}
+          >
+            <Github className="size-4" />
+            Login with GitHub
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AddMachineDialog({
+  hasCopiedInstallCommand,
+  installCommand,
+  installScriptHref,
+  onClose,
+  onCopy
+}: {
+  hasCopiedInstallCommand: boolean;
+  installCommand: string;
+  installScriptHref: string;
+  onClose(): void;
+  onCopy(): void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-end bg-black/70 p-4 sm:items-center sm:justify-center">
+      <div className="w-full max-w-xl rounded-lg border border-neutral-800 bg-neutral-950 p-4 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <Text className="block text-base font-semibold text-neutral-100">Add a machine</Text>
+            <Text className="mt-1 block text-sm text-neutral-500">
+              Run this on the Mac you want to add. It installs the connector and keeps it running.
+            </Text>
+          </div>
+          <Button aria-label="Close add machine" isIconOnly size="sm" variant="ghost" onPress={onClose}>
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <div className="mt-4 rounded-lg bg-black px-3 py-3">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium text-neutral-500">
+            <Terminal className="size-3.5" />
+            macOS arm64
+          </div>
+          <code className="block whitespace-pre-wrap break-all font-mono text-sm text-neutral-100">
+            {installCommand}
+          </code>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button size="sm" onPress={onCopy}>
+            {hasCopiedInstallCommand ? <Check className="size-4" /> : <Copy className="size-4" />}
+            {hasCopiedInstallCommand ? 'Copied' : 'Copy command'}
+          </Button>
+          <a href={installScriptHref} target="_blank" rel="noreferrer">
+            <Button size="sm" variant="outline">
+              <ExternalLink className="size-4" />
+              Open script
+            </Button>
+          </a>
+          <a href="/connector" target="_blank" rel="noreferrer">
+            <Button size="sm" variant="ghost">
+              Install guide
+            </Button>
+          </a>
+        </div>
+
+        <Text className="mt-3 block text-xs text-neutral-600">
+          Linux packaging is not published yet. Build from source or run a matching connector binary with PROJECT_CONNECTOR_HUB_URL set to this site.
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/project-home-overview.tsx
+++ b/src/features/project-desktop/components/project-home-overview.tsx
@@ -1,28 +1,26 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
-  Check,
-  Copy,
-  ExternalLink,
-  Github,
   Grid2X2,
-  Info,
   List,
   Plus,
   RefreshCw,
-  Terminal,
-  X,
 } from 'lucide-react';
-import { Button, Chip, Tab, TabIndicator, TabList, Tabs, Text, Tooltip } from '@/app/dotnaos-ui';
+import {
+  Button,
+  Chip,
+  Tab,
+  TabIndicator,
+  TabList,
+  Tabs,
+  Text,
+  Tooltip
+} from '@/app/dotnaos-ui';
 import { projectSpaceClient } from '@/api/project-space-client';
 import type {
   ConnectorOverviewResult,
-  FullstackTemplateStatus,
-  GitHubCatalogRepository,
   GitHubCatalogResult,
   GitHubOAuthDeviceStartResult,
-  GitHubProjectConfigStatus,
   MachineRecord,
-  ProjectWorktreeRecord,
   ProjectSpaceRecord
 } from '@/shared/project-space-api';
 import {
@@ -32,6 +30,29 @@ import {
   MachineDeviceIcon,
   MachineOsMark
 } from './machine-visuals';
+import {
+  AddMachineDialog,
+  BranchChips,
+  GitHubConnectPanel,
+  MachineDetailsTooltip,
+  MainListSearch,
+  ProjectListItem
+} from './project-home-overview-widgets';
+import {
+  branchesFromWorktrees,
+  configChipClass,
+  getMachineId,
+  getProjectMachineId,
+  getTemplateStatus,
+  installScriptUrl,
+  isVisibleLocalProject,
+  matchesQuery,
+  mergeBranchChips,
+  projectMatchesRepo,
+  templateStatusLabels,
+  type BranchChipRecord,
+  type MatrixRow
+} from './project-home-overview-model';
 
 interface ProjectHomeOverviewProps {
   connector: ConnectorOverviewResult;
@@ -44,287 +65,6 @@ interface ProjectHomeOverviewProps {
   onSelectMachine(machineId: string): void;
   projects: ProjectSpaceRecord[];
   onSelectProject(projectId: string): void;
-}
-
-interface LocalMatch {
-  machineId: string;
-  project: ProjectSpaceRecord;
-}
-
-interface MatrixRow {
-  id: string;
-  isLocalOnly: boolean;
-  localMatches: LocalMatch[];
-  repo?: GitHubCatalogRepository;
-  title: string;
-}
-
-interface BranchChipRecord {
-  isBase: boolean;
-  name: string;
-}
-
-const templateStatusLabels: Record<FullstackTemplateStatus, string> = {
-  implemented: 'ok',
-  partial: 'partial',
-  'not-detected': 'missing',
-  'template-source': 'template'
-};
-
-function getMachineId(project: ProjectSpaceRecord) {
-  return project.id.includes(':') ? project.id.slice(0, project.id.indexOf(':')) : 'local';
-}
-
-function getProjectMachineId(project: ProjectSpaceRecord, localMachineId: string) {
-  const machineId = getMachineId(project);
-  return machineId === 'local' ? localMachineId : machineId;
-}
-
-function getTemplateStatus(project: ProjectSpaceRecord): FullstackTemplateStatus {
-  return project.fullstackTemplate?.status ?? 'not-detected';
-}
-
-function basename(path: string) {
-  return path.split('/').filter(Boolean).at(-1) ?? path;
-}
-
-function isVisibleLocalProject(project: ProjectSpaceRecord) {
-  if (project.kind === 'github') {
-    return false;
-  }
-
-  const projectFolder = basename(project.rootPath);
-
-  return !projectFolder.startsWith('.') && !projectFolder.endsWith('.worktrees');
-}
-
-function normalizeKey(value: string) {
-  return value.trim().replace(/^@/, '').toLowerCase();
-}
-
-function projectKeys(project: ProjectSpaceRecord) {
-  const name = normalizeKey(project.name);
-  const rootName = normalizeKey(basename(project.rootPath));
-  const keys = new Set([name, rootName]);
-
-  if (name.includes('/')) {
-    keys.add(name.split('/').at(-1) ?? name);
-  }
-
-  return keys;
-}
-
-function projectMatchesRepo(project: ProjectSpaceRecord, repo: GitHubCatalogRepository) {
-  const keys = projectKeys(project);
-  const fullName = normalizeKey(repo.fullName);
-  const name = normalizeKey(repo.name);
-
-  return keys.has(fullName) || keys.has(name);
-}
-
-function isBaseBranchName(branchName: string, defaultBranch?: string) {
-  const normalizedBranch = normalizeKey(branchName);
-  const normalizedDefault = defaultBranch ? normalizeKey(defaultBranch) : '';
-
-  return (
-    (normalizedDefault && normalizedBranch === normalizedDefault) ||
-    normalizedBranch === 'main' ||
-    normalizedBranch === 'master'
-  );
-}
-
-function branchesFromWorktrees(
-  worktrees: ProjectWorktreeRecord[],
-  defaultBranch?: string
-): BranchChipRecord[] {
-  const branches = new Map<string, BranchChipRecord>();
-
-  for (const worktree of worktrees) {
-    const branchName = worktree.branchName?.trim();
-
-    if (!branchName) {
-      continue;
-    }
-
-    branches.set(branchName, {
-      isBase: isBaseBranchName(branchName, defaultBranch),
-      name: branchName
-    });
-  }
-
-  return Array.from(branches.values()).sort((left, right) => {
-    if (left.isBase !== right.isBase) {
-      return left.isBase ? -1 : 1;
-    }
-
-    return left.name.localeCompare(right.name);
-  });
-}
-
-function mergeBranchChips(
-  defaultBranch: string | undefined,
-  branchGroups: BranchChipRecord[][]
-) {
-  const branches = new Map<string, BranchChipRecord>();
-
-  if (defaultBranch) {
-    branches.set(defaultBranch, {
-      isBase: true,
-      name: defaultBranch
-    });
-  }
-
-  for (const group of branchGroups) {
-    for (const branch of group) {
-      const existing = branches.get(branch.name);
-
-      branches.set(branch.name, {
-        isBase: existing?.isBase || branch.isBase || isBaseBranchName(branch.name, defaultBranch),
-        name: branch.name
-      });
-    }
-  }
-
-  return Array.from(branches.values()).sort((left, right) => {
-    if (left.isBase !== right.isBase) {
-      return left.isBase ? -1 : 1;
-    }
-
-    return left.name.localeCompare(right.name);
-  });
-}
-
-function configChipClass(status: GitHubProjectConfigStatus | FullstackTemplateStatus) {
-  if (status === 'complete' || status === 'implemented' || status === 'template-source') {
-    return 'text-emerald-300';
-  }
-
-  if (status === 'partial') {
-    return 'text-amber-300';
-  }
-
-  return 'text-neutral-500';
-}
-
-function formatLastSeen(value?: string) {
-  if (!value) {
-    return 'not seen';
-  }
-
-  const timestamp = Date.parse(value);
-
-  if (!Number.isFinite(timestamp)) {
-    return value;
-  }
-
-  const minutes = Math.max(0, Math.round((Date.now() - timestamp) / 60_000));
-
-  if (minutes < 1) {
-    return 'now';
-  }
-
-  if (minutes < 60) {
-    return `${minutes}m`;
-  }
-
-  const hours = Math.round(minutes / 60);
-  return hours < 24 ? `${hours}h` : `${Math.round(hours / 24)}d`;
-}
-
-function DetailRow({ label, mono, value }: { label: string; mono?: boolean; value: string }) {
-  return (
-    <div className="flex items-baseline justify-between gap-3">
-      <span className="shrink-0 text-[10px] font-medium text-neutral-500">{label}</span>
-      <span
-        className={[
-          'min-w-0 truncate text-right text-neutral-200',
-          mono ? 'font-mono text-[11px]' : 'text-xs'
-        ].join(' ')}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function installScriptUrl() {
-  if (typeof window === 'undefined') {
-    return '/connector/install.sh';
-  }
-
-  return `${window.location.origin}/connector/install.sh`;
-}
-
-function MachineDetailsTooltip({
-  machine,
-  projectCount
-}: {
-  machine: MachineRecord;
-  projectCount: number;
-}) {
-  const origin =
-    machine.connector.origin ?? machine.network.tailscaleIp ?? machine.connector.installCommand;
-
-  return (
-    <Tooltip delay={150}>
-      <Tooltip.Trigger className="inline-flex">
-        <span
-          aria-label={`${machine.name} details`}
-          className="inline-flex size-5 items-center justify-center rounded-full text-neutral-600 transition hover:text-neutral-300"
-        >
-          <Info className="size-3.5" strokeWidth={1.8} />
-        </span>
-      </Tooltip.Trigger>
-      <Tooltip.Content className="w-56 space-y-1.5">
-        {machine.connector.serviceName ? (
-          <DetailRow label="Service" value={machine.connector.serviceName} />
-        ) : null}
-        <DetailRow label="Status" value={machine.connector.status} />
-        <DetailRow label="Projects" value={String(projectCount)} />
-        <DetailRow label="Last seen" value={formatLastSeen(machine.connector.lastSeen)} />
-        {origin ? <DetailRow label="Origin" mono value={origin} /> : null}
-      </Tooltip.Content>
-    </Tooltip>
-  );
-}
-
-function BranchChips({ branches }: { branches: BranchChipRecord[] }) {
-  if (branches.length === 0) {
-    return null;
-  }
-
-  const visibleBranches = branches.slice(0, 3);
-  const hiddenCount = branches.length - visibleBranches.length;
-
-  return (
-    <div
-      aria-label="Branches"
-      className="flex max-w-[17rem] shrink-0 items-center gap-1 overflow-x-auto"
-    >
-      {visibleBranches.map((branch) => (
-        <span
-          key={branch.name}
-          title={branch.name}
-          className={[
-            'inline-flex max-w-28 shrink-0 items-center truncate rounded-full px-2 py-0.5 text-[11px] font-medium',
-            branch.isBase
-              ? 'bg-neutral-100 text-neutral-950'
-              : 'bg-neutral-800/80 text-neutral-300'
-          ].join(' ')}
-        >
-          {branch.name}
-        </span>
-      ))}
-      {hiddenCount > 0 ? (
-        <span
-          title={branches.slice(3).map((branch) => branch.name).join(', ')}
-          className="inline-flex shrink-0 rounded-full bg-neutral-900 px-2 py-0.5 text-[11px] font-medium text-neutral-500"
-        >
-          +{hiddenCount}
-        </span>
-      ) : null}
-    </div>
-  );
 }
 
 export function ProjectHomeOverview({
@@ -350,6 +90,8 @@ export function ProjectHomeOverview({
   const [installScriptHref, setInstallScriptHref] = useState('/connector/install.sh');
   const [hasCopiedInstallCommand, setHasCopiedInstallCommand] = useState(false);
   const [layout, setLayout] = useState<'grid' | 'list'>('list');
+  const [machineQuery, setMachineQuery] = useState('');
+  const [projectQuery, setProjectQuery] = useState('');
   const [selectedMachineId, setSelectedMachineId] = useState('');
 
   async function refresh(includeConnector: boolean) {
@@ -438,8 +180,29 @@ export function ProjectHomeOverview({
     machines.find((machine) => machine.connector.status === 'local')?.id ??
     machines[0]?.id ??
     'local';
-  const connectedMachines = machines.filter(isMachineConnected);
-  const disconnectedMachines = machines.filter((machine) => !isMachineConnected(machine));
+  const filteredMachines = useMemo(
+    () =>
+      machines.filter((machine) =>
+        matchesQuery(
+          [
+            machine.name,
+            machine.id,
+            machine.kind,
+            machine.profile,
+            machine.primaryUser,
+            machine.network.localName,
+            machine.network.sshUser,
+            machine.network.tailscaleIp,
+            machine.connector.serviceName,
+            machine.connector.status
+          ],
+          machineQuery
+        )
+      ),
+    [machineQuery, machines]
+  );
+  const connectedMachines = filteredMachines.filter(isMachineConnected);
+  const disconnectedMachines = filteredMachines.filter((machine) => !isMachineConnected(machine));
   const activeMachineId = selectedMachineId || localMachineId || machines[0]?.id || '';
   const activeMachine = machinesById.get(activeMachineId);
 
@@ -499,6 +262,23 @@ export function ProjectHomeOverview({
   }, [localMachineId, projects]);
   const activeMachineProjects = activeMachineId ? projectsByMachine[activeMachineId] ?? [] : [];
   const githubRows = rows.filter((row) => !row.isLocalOnly);
+  const filteredGithubRows = useMemo(
+    () =>
+      githubRows.filter((row) =>
+        matchesQuery(
+          [
+            row.title,
+            row.repo?.fullName,
+            row.repo?.name,
+            row.repo?.owner,
+            row.repo?.description,
+            row.localMatches.map((match) => match.project.name).join(' ')
+          ],
+          projectQuery
+        )
+      ),
+    [githubRows, projectQuery]
+  );
   const branchSourceProjects = useMemo(() => {
     if (mode !== 'projects') {
       return [];
@@ -519,7 +299,7 @@ export function ProjectHomeOverview({
   const githubRowGroups = useMemo(() => {
     const groups = new Map<string, MatrixRow[]>();
 
-    for (const row of githubRows) {
+    for (const row of filteredGithubRows) {
       const owner = row.repo?.owner ?? 'Other';
       const items = groups.get(owner) ?? [];
       items.push(row);
@@ -532,7 +312,7 @@ export function ProjectHomeOverview({
         owner
       }))
       .sort((left, right) => left.owner.localeCompare(right.owner));
-  }, [githubRows]);
+  }, [filteredGithubRows]);
 
   useEffect(() => {
     const missingProjects = branchSourceProjects.filter(
@@ -737,197 +517,17 @@ export function ProjectHomeOverview({
     );
   }
 
-  function projectIdForRow(row: MatrixRow) {
-    return row.localMatches[0]?.project.id ?? (row.repo ? `github:${row.repo.fullName}` : '');
-  }
-
-  function renderGitHubLink(repo: GitHubCatalogRepository, label: string) {
-    return (
-      <a
-        href={repo.url}
-        target="_blank"
-        rel="noreferrer"
-        aria-label={`Open ${repo.fullName} on GitHub`}
-        onClick={(event) => event.stopPropagation()}
-        className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-neutral-600 transition hover:bg-neutral-900 hover:text-neutral-200"
-        title={label}
-      >
-        <ExternalLink className="size-3.5" />
-      </a>
-    );
-  }
-
-  function renderProjectRow(row: MatrixRow) {
-    const branches = branchesForRow(row);
-    const projectId = projectIdForRow(row);
-
-    return (
-      <div
-        key={row.id}
-        className="flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 transition hover:bg-neutral-900/40"
-      >
-        <button
-          type="button"
-          onClick={() => projectId && onSelectProject(projectId)}
-          className="min-w-0 flex-1 text-left"
-        >
-          <Text className="block min-w-0 truncate text-sm font-medium text-neutral-100">
-            {row.repo?.name ?? row.title}
-          </Text>
-        </button>
-        <BranchChips branches={branches} />
-        {row.repo ? renderGitHubLink(row.repo, 'Open on GitHub') : null}
-      </div>
-    );
-  }
-
-  function renderProjectCard(row: MatrixRow) {
-    const branches = branchesForRow(row);
-    const projectId = projectIdForRow(row);
-
-    return (
-      <div
-        key={row.id}
-        className="group flex min-w-0 flex-col gap-4 rounded-lg border border-neutral-900 bg-neutral-950/45 p-4 transition hover:border-neutral-800 hover:bg-neutral-950/70"
-      >
-        <div className="flex min-w-0 items-start justify-between gap-3">
-          <button
-            type="button"
-            onClick={() => projectId && onSelectProject(projectId)}
-            className="min-w-0 flex-1 text-left"
-          >
-            <Text className="block min-w-0 truncate text-sm font-semibold text-neutral-100">
-              {row.repo?.name ?? row.title}
-            </Text>
-            <Text className="mt-1 block truncate text-xs text-neutral-500">
-              {row.repo?.owner ?? 'Local'}
-            </Text>
-          </button>
-          {row.repo ? renderGitHubLink(row.repo, 'Open on GitHub') : null}
-        </div>
-        <BranchChips branches={branches} />
-      </div>
-    );
-  }
-
-  function renderGitHubConnectPanel() {
-    if (githubCatalog.status === 'connected') {
-      return null;
-    }
-
-    return (
-      <div className="mb-4 rounded-lg bg-neutral-950/60 px-4 py-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <Text className="block text-sm font-semibold text-neutral-100">
-              Connect GitHub
-            </Text>
-            <Text className="mt-1 block text-sm text-neutral-500">
-              {githubFlow?.status === 'pending'
-                ? 'Enter this code on GitHub, then check the login here.'
-                : githubCatalog.message ?? 'Connect GitHub to load repositories.'}
-            </Text>
-          </div>
-          {githubFlow?.status === 'pending' ? (
-            <div className="flex shrink-0 flex-wrap items-center gap-2">
-              <span className="rounded-lg bg-neutral-900 px-3 py-1.5 font-mono text-sm font-semibold text-neutral-100">
-                {githubFlow.userCode}
-              </span>
-              {githubFlow.verificationUri ? (
-                <a href={githubFlow.verificationUri} target="_blank" rel="noreferrer">
-                  <Button size="sm" variant="outline">
-                    <ExternalLink className="size-4" />
-                    Open GitHub
-                  </Button>
-                </a>
-              ) : null}
-              <Button size="sm" isDisabled={isConnectingGitHub} onPress={() => void pollGitHubLogin()}>
-                Check login
-              </Button>
-            </div>
-          ) : (
-            <Button
-              className="shrink-0"
-              size="sm"
-              isDisabled={isConnectingGitHub || githubCatalog.status === 'not-configured'}
-              onPress={() => void connectGitHub()}
-            >
-              <Github className="size-4" />
-              Login with GitHub
-            </Button>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  function renderInstallDialog() {
-    if (!isInstallDialogOpen) {
-      return null;
-    }
-
-    return (
-      <div className="fixed inset-0 z-50 flex items-end bg-black/70 p-4 sm:items-center sm:justify-center">
-        <div className="w-full max-w-xl rounded-lg border border-neutral-800 bg-neutral-950 p-4 shadow-2xl">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <Text className="block text-base font-semibold text-neutral-100">
-                Add a machine
-              </Text>
-              <Text className="mt-1 block text-sm text-neutral-500">
-                Run this on the Mac you want to add. It installs the connector and keeps it running.
-              </Text>
-            </div>
-            <Button
-              aria-label="Close add machine"
-              isIconOnly
-              size="sm"
-              variant="ghost"
-              onPress={() => setIsInstallDialogOpen(false)}
-            >
-              <X className="size-4" />
-            </Button>
-          </div>
-
-          <div className="mt-4 rounded-lg bg-black px-3 py-3">
-            <div className="mb-2 flex items-center gap-2 text-xs font-medium text-neutral-500">
-              <Terminal className="size-3.5" />
-              macOS arm64
-            </div>
-            <code className="block whitespace-pre-wrap break-all font-mono text-sm text-neutral-100">
-              {installCommand}
-            </code>
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Button size="sm" onPress={() => void copyInstallCommand()}>
-              {hasCopiedInstallCommand ? <Check className="size-4" /> : <Copy className="size-4" />}
-              {hasCopiedInstallCommand ? 'Copied' : 'Copy command'}
-            </Button>
-            <a href={installScriptHref} target="_blank" rel="noreferrer">
-              <Button size="sm" variant="outline">
-                <ExternalLink className="size-4" />
-                Open script
-              </Button>
-            </a>
-            <a href="/connector" target="_blank" rel="noreferrer">
-              <Button size="sm" variant="ghost">
-                Install guide
-              </Button>
-            </a>
-          </div>
-
-          <Text className="mt-3 block text-xs text-neutral-600">
-            Linux packaging is not published yet. Build from source or run a matching connector binary with PROJECT_CONNECTOR_HUB_URL set to this site.
-          </Text>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex min-h-full w-full flex-col">
-      {renderInstallDialog()}
+      {isInstallDialogOpen ? (
+        <AddMachineDialog
+          hasCopiedInstallCommand={hasCopiedInstallCommand}
+          installCommand={installCommand}
+          installScriptHref={installScriptHref}
+          onClose={() => setIsInstallDialogOpen(false)}
+          onCopy={() => void copyInstallCommand()}
+        />
+      ) : null}
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="min-w-0">
           {mode === 'machines' ? (
@@ -968,11 +568,36 @@ export function ProjectHomeOverview({
         </div>
       </div>
 
+      {mode === 'machines' || githubCatalog.status === 'connected' ? (
+        <div className="mb-4">
+          {mode === 'machines' ? (
+            <MainListSearch
+              label="Search machines"
+              placeholder="Search machines"
+              value={machineQuery}
+              onChange={setMachineQuery}
+            />
+          ) : (
+            <MainListSearch
+              label="Search projects"
+              placeholder="Search projects"
+              value={projectQuery}
+              onChange={setProjectQuery}
+            />
+          )}
+        </div>
+      ) : null}
+
       {mode === 'machines' ? (
         <>
           <div className="mb-4 space-y-4">
             {renderMachineSection('Connected', connectedMachines)}
             {renderMachineSection('Disconnected', disconnectedMachines)}
+            {filteredMachines.length === 0 ? (
+              <div className="rounded-lg bg-neutral-950/45 px-4 py-6">
+                <Text className="text-sm text-neutral-500">No machines found.</Text>
+              </div>
+            ) : null}
           </div>
 
           <div className="mb-3">
@@ -1019,7 +644,15 @@ export function ProjectHomeOverview({
         </>
       ) : null}
 
-      {mode === 'projects' ? renderGitHubConnectPanel() : null}
+      {mode === 'projects' ? (
+        <GitHubConnectPanel
+          flow={githubFlow}
+          githubCatalog={githubCatalog}
+          isConnecting={isConnectingGitHub}
+          onConnect={() => void connectGitHub()}
+          onPoll={() => void pollGitHubLogin()}
+        />
+      ) : null}
 
       {mode === 'projects' ? (
         <div className="flex max-h-[70vh] flex-col overflow-y-auto">
@@ -1029,10 +662,23 @@ export function ProjectHomeOverview({
                 {group.owner}
               </Text>
               <div className={layout === 'grid' ? 'grid gap-3 md:grid-cols-2 xl:grid-cols-3' : 'flex flex-col'}>
-                {group.items.map(layout === 'grid' ? renderProjectCard : renderProjectRow)}
+                {group.items.map((row) => (
+                  <ProjectListItem
+                    key={row.id}
+                    branches={branchesForRow(row)}
+                    layout={layout}
+                    onSelectProject={onSelectProject}
+                    row={row}
+                  />
+                ))}
               </div>
             </div>
           ))}
+          {githubCatalog.status === 'connected' && filteredGithubRows.length === 0 ? (
+            <div className="rounded-lg bg-neutral-950/45 px-4 py-6">
+              <Text className="text-sm text-neutral-500">No projects found.</Text>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/features/project-desktop/components/project-main-breadcrumbs.tsx
+++ b/src/features/project-desktop/components/project-main-breadcrumbs.tsx
@@ -1,0 +1,69 @@
+import { Button, Text } from '@/app/dotnaos-ui';
+import { ArrowLeft, ChevronRight } from 'lucide-react';
+
+export interface MainBreadcrumbItem {
+  label: string;
+  onPress?: () => void;
+}
+
+export function MainBreadcrumbs({
+  items,
+  onBack
+}: {
+  items: MainBreadcrumbItem[];
+  onBack?: () => void;
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-5 flex min-w-0 items-center gap-3">
+      {onBack ? (
+        <Button aria-label="Back" isIconOnly size="sm" variant="ghost" onPress={onBack}>
+          <ArrowLeft className="size-4" />
+        </Button>
+      ) : null}
+      <nav
+        aria-label="Main breadcrumb"
+        className="flex min-w-0 items-center gap-1 text-xs text-neutral-500"
+      >
+        {items.map((item, index) => {
+          const isCurrent = index === items.length - 1;
+          const label = (
+            <span className="block max-w-[16rem] truncate" title={item.label}>
+              {item.label}
+            </span>
+          );
+
+          return (
+            <span key={`${item.label}-${index}`} className="flex min-w-0 items-center gap-1">
+              {index > 0 ? (
+                <ChevronRight className="size-3 shrink-0 text-neutral-700" strokeWidth={1.8} />
+              ) : null}
+              {item.onPress && !isCurrent ? (
+                <button
+                  type="button"
+                  onClick={item.onPress}
+                  className="min-w-0 rounded-md px-1.5 py-1 text-left transition hover:bg-neutral-900 hover:text-neutral-200"
+                >
+                  {label}
+                </button>
+              ) : (
+                <Text
+                  className={
+                    isCurrent
+                      ? 'min-w-0 px-1.5 py-1 text-neutral-300'
+                      : 'min-w-0 px-1.5 py-1'
+                  }
+                >
+                  {label}
+                </Text>
+              )}
+            </span>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/project-main-model.ts
+++ b/src/features/project-desktop/components/project-main-model.ts
@@ -1,0 +1,122 @@
+import type {
+  GitHubCatalogRepository,
+  GitHubCatalogResult,
+  GitHubRepositoryDetailsResult,
+  MachineRecord,
+  ProjectSpaceRecord
+} from '@/shared/project-space-api';
+
+export function getProjectTimestamp(project: ProjectSpaceRecord) {
+  const value = project.github?.updatedAt ?? project.github?.pushedAt;
+  const timestamp = value ? Date.parse(value) : NaN;
+
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function formatRelativeTime(timestamp: number) {
+  if (!timestamp) {
+    return '';
+  }
+
+  const minutes = Math.max(0, Math.round((Date.now() - timestamp) / 60_000));
+
+  if (minutes < 1) {
+    return 'now';
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+
+  return `${Math.round(hours / 24)}d`;
+}
+
+export function machineSubtitle(machine: MachineRecord) {
+  return [machine.kind, machine.profile, machine.network.localName].filter(Boolean).join(' / ');
+}
+
+export function getMachineId(project: ProjectSpaceRecord) {
+  return project.id.includes(':') ? project.id.slice(0, project.id.indexOf(':')) : 'local';
+}
+
+export function getProjectMachineId(project: ProjectSpaceRecord, localMachineId: string) {
+  const machineId = getMachineId(project);
+  return machineId === 'local' ? localMachineId : machineId;
+}
+
+export function formatOptionalTime(value?: string) {
+  if (!value) {
+    return 'not seen';
+  }
+
+  const timestamp = Date.parse(value);
+
+  if (!Number.isFinite(timestamp)) {
+    return value;
+  }
+
+  return formatRelativeTime(timestamp);
+}
+
+export function isVisibleProject(project: ProjectSpaceRecord) {
+  if (project.kind === 'github') {
+    return true;
+  }
+
+  const folder = project.rootPath.split('/').filter(Boolean).pop() ?? '';
+
+  return !folder.startsWith('.') && !folder.endsWith('.worktrees');
+}
+
+function basenamePath(path: string) {
+  return path.split('/').filter(Boolean).pop() ?? path;
+}
+
+function normalizeKey(value: string) {
+  return value.trim().replace(/^@/, '').toLowerCase();
+}
+
+function projectMatchesRepository(project: ProjectSpaceRecord, repo: GitHubCatalogRepository) {
+  const projectName = normalizeKey(project.name);
+  const projectFolder = normalizeKey(basenamePath(project.rootPath));
+  const repoFullName = normalizeKey(repo.fullName);
+  const repoName = normalizeKey(repo.name);
+
+  return (
+    projectName === repoFullName ||
+    projectName === repoName ||
+    projectFolder === repoFullName ||
+    projectFolder === repoName
+  );
+}
+
+export function resolveProjectRepository(
+  project: ProjectSpaceRecord | undefined,
+  githubCatalog: GitHubCatalogResult
+) {
+  if (!project || githubCatalog.status !== 'connected') {
+    return project?.github;
+  }
+
+  return (
+    project.github ??
+    githubCatalog.repositories.find((repo) => projectMatchesRepository(project, repo))
+  );
+}
+
+export function repositoryDetailsFallback(
+  status: GitHubCatalogResult['status']
+): GitHubRepositoryDetailsResult {
+  return {
+    branches: [],
+    checkedAt: new Date().toISOString(),
+    issues: [],
+    status
+  };
+}

--- a/src/features/project-desktop/components/project-main-panel.tsx
+++ b/src/features/project-desktop/components/project-main-panel.tsx
@@ -1,42 +1,27 @@
 import type {
   ConnectorOverviewResult,
   ExplorerTarget,
-  GitHubCatalogRepository,
   GitHubCatalogResult,
-  GitHubRepositoryDetailsResult,
   LauncherAppRecord,
   MachineRecord,
   ProjectSpaceRecord
 } from '@/shared/project-space-api';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { ProjectMainView } from '../hooks/use-project-desktop';
-import {
-  ChevronDown,
-  ExternalLink,
-  GitBranch,
-  ListChecks,
-  Play,
-  Server,
-  Terminal as TerminalIcon
-} from 'lucide-react';
-import { WTerm } from '@wterm/dom';
-import '@wterm/dom/css';
+import { ChevronDown, ExternalLink, Play, Server } from 'lucide-react';
 import { Button, Card, Chip, Surface, Text } from '@/app/dotnaos-ui';
-import { projectSpaceClient, refreshProjectSpaceAuthToken } from '@/api/project-space-client';
 import { OpenTargetDropdown } from './open-target-dropdown';
+import { MachineDetailView } from './machine-detail-view';
+import { MainBreadcrumbs, type MainBreadcrumbItem } from './project-main-breadcrumbs';
 import { ProjectCliCommandPanel } from './project-cli-command-panel';
 import { ProjectHomeOverview } from './project-home-overview';
 import { ProjectOperationsPanel } from './project-operations-panel';
+import { ProjectRootOverview } from './project-root-overview';
 import { ProjectTemplateCheckPanel } from './project-template-check';
 import { ProjectWorkspaceTools } from './project-workspace-tools';
 import { ProjectctlManifestPanel } from './projectctl-manifest-panel';
-import {
-  isMachineConnected,
-  MachineBatteryMeter,
-  MachineConnectionIcon,
-  MachineDeviceIcon,
-  MachineOsMark
-} from './machine-visuals';
+import { RepositoryActivityPanel } from './repository-activity-panel';
+import { resolveProjectRepository } from './project-main-model';
 
 interface ProjectMainPanelProps {
   connectorOverview: ConnectorOverviewResult;
@@ -62,6 +47,7 @@ interface ProjectMainPanelProps {
   onOpenMachines(): void;
   onOpenMachine(machineId: string): void;
   onOpenProjects(): void;
+  onOpenRoot(): void;
   onOpenSelectedTarget(): void;
   onRefreshConnectorOverview(): Promise<ConnectorOverviewResult>;
   onRefreshGitHubCatalog(): Promise<GitHubCatalogResult>;
@@ -69,734 +55,256 @@ interface ProjectMainPanelProps {
   onSelectProject(projectId: string): void;
 }
 
-function getProjectTimestamp(project: ProjectSpaceRecord) {
-  const value = project.github?.updatedAt ?? project.github?.pushedAt;
-  const timestamp = value ? Date.parse(value) : NaN;
-
-  return Number.isFinite(timestamp) ? timestamp : 0;
-}
-
-function formatRelativeTime(timestamp: number) {
-  if (!timestamp) {
-    return '';
-  }
-
-  const minutes = Math.max(0, Math.round((Date.now() - timestamp) / 60_000));
-
-  if (minutes < 1) {
-    return 'now';
-  }
-
-  if (minutes < 60) {
-    return `${minutes}m`;
-  }
-
-  const hours = Math.round(minutes / 60);
-
-  if (hours < 24) {
-    return `${hours}h`;
-  }
-
-  return `${Math.round(hours / 24)}d`;
-}
-
-function machineSubtitle(machine: MachineRecord) {
-  return [machine.kind, machine.profile, machine.network.localName].filter(Boolean).join(' / ');
-}
-
-function getMachineId(project: ProjectSpaceRecord) {
-  return project.id.includes(':') ? project.id.slice(0, project.id.indexOf(':')) : 'local';
-}
-
-function getProjectMachineId(project: ProjectSpaceRecord, localMachineId: string) {
-  const machineId = getMachineId(project);
-  return machineId === 'local' ? localMachineId : machineId;
-}
-
-function formatOptionalTime(value?: string) {
-  if (!value) {
-    return 'not seen';
-  }
-
-  const timestamp = Date.parse(value);
-
-  if (!Number.isFinite(timestamp)) {
-    return value;
-  }
-
-  return formatRelativeTime(timestamp);
-}
-
-function isVisibleProject(project: ProjectSpaceRecord) {
-  if (project.kind === 'github') {
-    return true;
-  }
-
-  const folder = project.rootPath.split('/').filter(Boolean).pop() ?? '';
-
-  return !folder.startsWith('.') && !folder.endsWith('.worktrees');
-}
-
-function basenamePath(path: string) {
-  return path.split('/').filter(Boolean).pop() ?? path;
-}
-
-function normalizeKey(value: string) {
-  return value.trim().replace(/^@/, '').toLowerCase();
-}
-
-function projectMatchesRepository(project: ProjectSpaceRecord, repo: GitHubCatalogRepository) {
-  const projectName = normalizeKey(project.name);
-  const projectFolder = normalizeKey(basenamePath(project.rootPath));
-  const repoFullName = normalizeKey(repo.fullName);
-  const repoName = normalizeKey(repo.name);
-
-  return (
-    projectName === repoFullName ||
-    projectName === repoName ||
-    projectFolder === repoFullName ||
-    projectFolder === repoName
-  );
-}
-
-function resolveProjectRepository(
-  project: ProjectSpaceRecord | undefined,
-  githubCatalog: GitHubCatalogResult
-) {
-  if (!project || githubCatalog.status !== 'connected') {
-    return project?.github;
-  }
-
-  return (
-    project.github ??
-    githubCatalog.repositories.find((repo) => projectMatchesRepository(project, repo))
-  );
-}
-
-function repositoryDetailsFallback(
-  status: GitHubCatalogResult['status']
-): GitHubRepositoryDetailsResult {
-  return {
-    branches: [],
-    checkedAt: new Date().toISOString(),
-    issues: [],
-    status
-  };
-}
-
-function RootOverview({
-  connector,
-  onOpenMachines,
-  onOpenMachine,
-  onOpenProjects,
-  onSelectProject,
-  projects
+function ProjectHeaderTitle({
+  mainView,
+  project,
+  selectedMachine,
+  selectedTargetName
 }: {
-  connector: ConnectorOverviewResult;
-  onOpenMachines(): void;
-  onOpenMachine(machineId: string): void;
-  onOpenProjects(): void;
-  onSelectProject(projectId: string): void;
-  projects: ProjectSpaceRecord[];
+  mainView: ProjectMainView;
+  project?: ProjectSpaceRecord;
+  selectedMachine?: MachineRecord;
+  selectedTargetName: string;
 }) {
-  const connectedMachines = connector.machines.filter(isMachineConnected);
-  const recentProjects = projects
-    .filter(isVisibleProject)
-    .sort((left, right) => {
-      const timestampDelta = getProjectTimestamp(right) - getProjectTimestamp(left);
-
-      return timestampDelta || left.name.localeCompare(right.name);
-    })
-    .slice(0, 8);
-  const hasProjectTimestamps = recentProjects.some((project) => getProjectTimestamp(project) > 0);
-
   return (
-    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-8 pt-4">
-      <section>
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <Text className="text-sm font-semibold text-neutral-100">Running machines</Text>
-          <Button size="sm" variant="ghost" onPress={onOpenMachines}>
-            View all
-          </Button>
-        </div>
-
-        {connectedMachines.length > 0 ? (
-          <div className="divide-y divide-neutral-900/80">
-            {connectedMachines.map((machine) => (
-              <button
-                key={machine.id}
-                type="button"
-                onClick={() => onOpenMachine(machine.id)}
-                className="flex w-full min-w-0 items-center gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
-              >
-                <MachineConnectionIcon machine={machine} />
-                <MachineDeviceIcon machine={machine} />
-                <span className="min-w-0 flex-1">
-                  <span className="flex min-w-0 items-center gap-1.5">
-                    <Text className="block truncate text-sm font-medium text-neutral-100">
-                      {machine.name}
-                    </Text>
-                    <MachineOsMark machine={machine} />
-                  </span>
-                  <Text className="block truncate text-xs text-neutral-500">
-                    {machineSubtitle(machine) || machine.connector.status}
-                  </Text>
-                </span>
-                <MachineBatteryMeter compact machine={machine} />
-              </button>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg bg-neutral-950/45 px-4 py-5">
-            <Text className="text-sm text-neutral-500">No machines are currently connected.</Text>
-          </div>
-        )}
-      </section>
-
-      <section>
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <Text className="text-sm font-semibold text-neutral-100">
-            {hasProjectTimestamps ? 'Recent projects' : 'Projects'}
-          </Text>
-          <Button size="sm" variant="ghost" onPress={onOpenProjects}>
-            View all
-          </Button>
-        </div>
-
-        {recentProjects.length > 0 ? (
-          <div className="divide-y divide-neutral-900/80">
-            {recentProjects.map((entry) => {
-              const timestamp = getProjectTimestamp(entry);
-              const label = entry.github?.name ?? entry.name;
-              const sublabel = entry.github?.owner ?? (entry.kind === 'github' ? 'GitHub' : 'Local');
-              const relative = formatRelativeTime(timestamp);
-
-              return (
-                <button
-                  key={entry.id}
-                  type="button"
-                  onClick={() => onSelectProject(entry.id)}
-                  className="flex w-full min-w-0 items-center justify-between gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
-                >
-                  <span className="min-w-0">
-                    <Text className="block truncate text-sm font-medium text-neutral-100">
-                      {label}
-                    </Text>
-                    <Text className="block truncate text-xs text-neutral-500">{sublabel}</Text>
-                  </span>
-                  {relative ? (
-                    <Text className="shrink-0 text-xs text-neutral-500">{relative}</Text>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="rounded-lg bg-neutral-950/45 px-4 py-5">
-            <Text className="text-sm text-neutral-500">No projects discovered yet.</Text>
-          </div>
-        )}
-      </section>
-    </div>
-  );
-}
-
-function MachineDetailRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex min-w-0 items-baseline justify-between gap-4 border-b border-neutral-900/70 py-2 last:border-b-0">
-      <Text className="shrink-0 text-xs font-medium text-neutral-500">{label}</Text>
-      <Text className="min-w-0 truncate text-right text-sm text-neutral-200">{value}</Text>
-    </div>
-  );
-}
-
-type MachineTerminalStatus = 'connecting' | 'connected' | 'closed' | 'error';
-
-const MachineTerminalSession = memo(function MachineTerminalSession({
-  canRun,
-  machineId,
-  onStatusChange,
-  sessionVersion
-}: {
-  canRun: boolean;
-  machineId: string;
-  onStatusChange(status: MachineTerminalStatus, message?: string): void;
-  sessionVersion: number;
-}) {
-  const terminalElementRef = useRef<HTMLDivElement | null>(null);
-  const terminalRef = useRef<WTerm | null>(null);
-  const socketRef = useRef<WebSocket | null>(null);
-  const sizeRef = useRef({ cols: 100, rows: 28 });
-
-  useEffect(() => {
-    const element = terminalElementRef.current;
-
-    if (!element) {
-      return;
-    }
-
-    let canceled = false;
-    const terminal = new WTerm(element, {
-      autoResize: true,
-      cols: 100,
-      cursorBlink: true,
-      onData(data) {
-        const socket = socketRef.current;
-
-        if (socket?.readyState === WebSocket.OPEN) {
-          socket.send(JSON.stringify({ data, type: 'input' }));
-        }
-      },
-      onResize(cols, rows) {
-        sizeRef.current = { cols, rows };
-        const socket = socketRef.current;
-
-        if (socket?.readyState === WebSocket.OPEN) {
-          socket.send(JSON.stringify({ cols, rows, type: 'resize' }));
-        }
-      },
-      rows: 28
-    });
-    terminalRef.current = terminal;
-
-    terminal
-      .init()
-      .then(async () => {
-        if (canceled) {
-          return;
-        }
-
-        if (!canRun) {
-          onStatusChange('closed');
-          return;
-        }
-
-        const { cols, rows } = sizeRef.current;
-        const baseUrl =
-          import.meta.env.VITE_PROJECT_SPACE_API_BASE_URL ||
-          new URL(window.location.href).searchParams.get('projectSpaceApi') ||
-          window.location.origin;
-        const url = new URL(`/api/machines/${encodeURIComponent(machineId)}/terminal`, baseUrl);
-        const sessionToken = await refreshProjectSpaceAuthToken();
-
-        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-        url.searchParams.set('cols', String(cols));
-        url.searchParams.set('rows', String(rows));
-        if (sessionToken) {
-          url.searchParams.set('session', sessionToken);
-        }
-        const socket = new WebSocket(url);
-        socketRef.current = socket;
-
-        onStatusChange('connecting');
-        terminal.write('\x1bc');
-
-        socket.addEventListener('open', () => {
-          if (canceled) {
-            return;
-          }
-
-          onStatusChange('connected');
-          terminal.focus();
-        });
-
-        socket.addEventListener('message', (event) => {
-          try {
-            const message = JSON.parse(String(event.data)) as {
-              data?: string;
-              exitCode?: number;
-              signal?: number;
-              type: 'output' | 'exit';
-            };
-
-            if (message.type === 'output' && typeof message.data === 'string') {
-              terminal.write(message.data);
-              return;
-            }
-
-            if (message.type === 'exit') {
-              terminal.write(
-                `\r\n[session exited: ${message.exitCode ?? message.signal ?? 'closed'}]\r\n`
-              );
-            }
-          } catch {
-            terminal.write(String(event.data));
-          }
-        });
-
-        socket.addEventListener('close', () => {
-          if (socketRef.current === socket) {
-            socketRef.current = null;
-          }
-
-          if (!canceled) {
-            onStatusChange('closed');
-          }
-        });
-
-        socket.addEventListener('error', () => {
-          if (!canceled) {
-            onStatusChange('error');
-            terminal.write('\r\n[terminal connection failed]\r\n');
-          }
-        });
-      })
-      .catch((error) => {
-        if (canceled) {
-          return;
-        }
-
-        onStatusChange(
-          'error',
-          `wterm failed to initialize: ${
-            error instanceof Error ? error.message : 'unknown error'
-          }`
-        );
-      });
-
-    return () => {
-      canceled = true;
-      socketRef.current?.close();
-      socketRef.current = null;
-      terminal.destroy();
-      if (terminalRef.current === terminal) {
-        terminalRef.current = null;
-      }
-      onStatusChange('closed');
-    };
-  }, [canRun, machineId, onStatusChange, sessionVersion]);
-
-  return <div ref={terminalElementRef} className="project-machine-terminal h-[28rem] w-full" />;
-}, (previous, next) => {
-  return (
-    previous.canRun === next.canRun &&
-    previous.machineId === next.machineId &&
-    previous.sessionVersion === next.sessionVersion
-  );
-});
-
-function MachineTerminalPanel({ machine }: { machine: MachineRecord }) {
-  const [sessionVersion, setSessionVersion] = useState(0);
-  const [errorMessage, setErrorMessage] = useState('');
-  const [status, setStatus] = useState<MachineTerminalStatus>('closed');
-  const canRun = isMachineConnected(machine);
-  const handleStatusChange = useCallback((nextStatus: MachineTerminalStatus, message?: string) => {
-    setErrorMessage(message ?? '');
-    setStatus(nextStatus);
-  }, []);
-
-  function reconnect() {
-    setSessionVersion((current) => current + 1);
-  }
-
-  return (
-    <Surface
-      variant="tertiary"
-      className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-    >
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <TerminalIcon className="size-4 text-neutral-400" />
-          <Text className="text-sm font-semibold text-neutral-100">Terminal</Text>
-        </div>
-        <Button size="sm" isDisabled={!canRun || status === 'connecting'} onPress={reconnect}>
-          {status === 'connected' ? 'Reconnect' : 'Connect'}
-        </Button>
-      </div>
-
-      {!canRun ? (
-        <Text className="block text-xs text-neutral-500">
-          This machine is not connected, so no shell is available right now.
-        </Text>
-      ) : null}
-      <div className="overflow-hidden rounded-lg border border-neutral-800 bg-black">
-        <MachineTerminalSession
-          canRun={canRun}
-          machineId={machine.id}
-          onStatusChange={handleStatusChange}
-          sessionVersion={sessionVersion}
-        />
-      </div>
-      <Text className="mt-2 block text-xs text-neutral-600">
-        {status === 'connected'
-          ? 'Live shell connected.'
-          : status === 'connecting'
-            ? 'Connecting shell...'
-            : status === 'error'
-              ? errorMessage || 'Terminal connection failed.'
-              : 'Terminal disconnected.'}
+    <div className="relative flex min-w-0 items-center gap-3 leading-none">
+      <Text className="truncate text-[15px] font-semibold text-neutral-100">
+        {mainView === 'root'
+          ? 'Project Space'
+          : mainView === 'machines'
+            ? 'Machines'
+            : mainView === 'machine'
+              ? selectedMachine?.name ?? 'Machine'
+              : mainView === 'projects'
+                ? 'Projects'
+                : project?.name ?? 'No project selected'}
       </Text>
-    </Surface>
+      {mainView === 'project' && project && project.kind !== 'github' ? (
+        <div className="hidden sm:block">
+          <Chip color="default" size="sm" variant="tertiary" className="shrink-0 text-neutral-400">
+            {selectedTargetName}
+          </Chip>
+        </div>
+      ) : null}
+    </div>
   );
 }
 
-function RepositoryActivityPanel({
-  repository
+function GitHubProjectView({
+  project,
+  selectedRepository
 }: {
-  repository?: GitHubCatalogRepository;
+  project: ProjectSpaceRecord & { github: NonNullable<ProjectSpaceRecord['github']> };
+  selectedRepository?: ProjectSpaceRecord['github'];
 }) {
-  const [details, setDetails] = useState<GitHubRepositoryDetailsResult>();
-  const [error, setError] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (!repository) {
-      setDetails(undefined);
-      return;
-    }
-
-    let canceled = false;
-
-    setError('');
-    setIsLoading(true);
-    projectSpaceClient
-      .getGitHubRepositoryDetails(repository.fullName)
-      .then((nextDetails) => {
-        if (!canceled) {
-          setDetails(nextDetails);
-        }
-      })
-      .catch((requestError) => {
-        if (!canceled) {
-          setError(
-            requestError instanceof Error
-              ? requestError.message
-              : 'Could not load repository details.'
-          );
-        }
-      })
-      .finally(() => {
-        if (!canceled) {
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      canceled = true;
-    };
-  }, [repository]);
-
-  if (!repository) {
-    return null;
-  }
-
-  const safeDetails = details ?? repositoryDetailsFallback('connected');
-  const issuesMessage =
-    error || safeDetails.message || (isLoading ? 'Loading repository details...' : '');
-
   return (
-    <section className="grid gap-3 lg:grid-cols-2">
-      <Surface
-        variant="tertiary"
-        className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-      >
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <GitBranch className="size-4 text-neutral-400" />
-            <Text className="text-sm font-semibold text-neutral-100">Branches</Text>
-          </div>
-          <Text className="text-xs text-neutral-500">{safeDetails.branches.length}</Text>
-        </div>
-        {safeDetails.branches.length > 0 ? (
-          <div className="flex max-h-64 flex-col overflow-auto">
-            {safeDetails.branches.map((branch) => (
-              <a
-                key={branch.name}
-                href={branch.url ?? repository.url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex min-w-0 items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm transition hover:bg-neutral-900/60"
-              >
-                <Text className="truncate text-neutral-200">{branch.name}</Text>
-                {branch.isDefault ? (
-                  <Chip size="sm" className="text-neutral-100">
-                    base
-                  </Chip>
-                ) : null}
-              </a>
-            ))}
-          </div>
-        ) : (
-          <Text className="text-sm text-neutral-500">
-            {issuesMessage || 'No branches loaded yet.'}
-          </Text>
-        )}
-      </Surface>
-
-      <Surface
-        variant="tertiary"
-        className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-      >
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <ListChecks className="size-4 text-neutral-400" />
-            <Text className="text-sm font-semibold text-neutral-100">Issues</Text>
-          </div>
-          <Text className="text-xs text-neutral-500">{safeDetails.issues.length}</Text>
-        </div>
-        {safeDetails.issues.length > 0 ? (
-          <div className="flex max-h-64 flex-col overflow-auto">
-            {safeDetails.issues.map((issue) => (
-              <a
-                key={issue.number}
-                href={issue.url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex min-w-0 items-start gap-3 rounded-lg px-2 py-2 transition hover:bg-neutral-900/60"
-              >
-                <Text className="shrink-0 text-xs text-neutral-500">#{issue.number}</Text>
-                <span className="min-w-0 flex-1">
-                  <Text className="block truncate text-sm font-medium text-neutral-100">
-                    {issue.title}
-                  </Text>
-                  {issue.author ? (
-                    <Text className="block truncate text-xs text-neutral-500">
-                      {issue.author}
-                    </Text>
-                  ) : null}
-                </span>
-              </a>
-            ))}
-          </div>
-        ) : (
-          <Text className="text-sm text-neutral-500">
-            {issuesMessage || 'No open issues.'}
-          </Text>
-        )}
-      </Surface>
-    </section>
-  );
-}
-
-function MachineDetailView({
-  connector,
-  machine,
-  machineId,
-  onOpenMachines,
-  onSelectProject,
-  projects
-}: {
-  connector: ConnectorOverviewResult;
-  machine?: MachineRecord;
-  machineId: string;
-  onOpenMachines(): void;
-  onSelectProject(projectId: string): void;
-  projects: ProjectSpaceRecord[];
-}) {
-  const localMachineId =
-    connector.machines.find((entry) => entry.connector.status === 'local')?.id ??
-    connector.machines[0]?.id ??
-    'local';
-  const machineProjects = machine
-    ? projects
-        .filter(isVisibleProject)
-        .filter((project) => project.kind !== 'github')
-        .filter((project) => getProjectMachineId(project, localMachineId) === machine.id)
-        .sort((left, right) => left.name.localeCompare(right.name))
-    : [];
-
-  if (!machine) {
-    return (
-      <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col justify-center gap-4">
-        <Text className="block text-2xl font-semibold text-neutral-100">Machine not found</Text>
-        <Text className="block text-sm text-neutral-500">
-          {machineId || 'This machine'} is not currently in the connector registry.
+    <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-4">
+      <section className="shrink-0 border-b border-neutral-800/70 pb-4">
+        <Text className="block text-[11px] font-medium text-neutral-500">GitHub repository</Text>
+        <Text className="mt-2 block truncate text-xl font-semibold text-neutral-50">
+          {project.github.fullName}
         </Text>
-        <Button className="w-fit" variant="secondary" onPress={onOpenMachines}>
-          Back to machines
-        </Button>
-      </div>
-    );
-  }
+        {project.github.description ? (
+          <Text className="mt-2 block text-sm text-neutral-500">
+            {project.github.description}
+          </Text>
+        ) : null}
+      </section>
 
-  const origin =
-    machine.connector.origin ?? machine.network.tailscaleIp ?? machine.connector.installCommand;
-
-  return (
-    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-5">
-      <section className="border-b border-neutral-800/70 pb-5">
-        <div className="flex min-w-0 flex-wrap items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
-              <MachineDeviceIcon machine={machine} />
-              <Text className="truncate text-2xl font-semibold text-neutral-50">
-                {machine.name}
-              </Text>
-              <MachineOsMark machine={machine} />
+      <section className="grid gap-3 sm:grid-cols-2">
+        <Surface
+          variant="tertiary"
+          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+        >
+          <Text className="block text-sm font-semibold text-neutral-100">Repository</Text>
+          <div className="mt-3 grid gap-2 text-sm">
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">Owner</Text>
+              <Text className="truncate text-neutral-200">{project.github.owner}</Text>
             </div>
-            <Text className="mt-1 block text-sm text-neutral-500">
-              {machineSubtitle(machine) || 'machine'}
-            </Text>
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">Default branch</Text>
+              <Text className="truncate text-neutral-200">
+                {project.github.defaultBranch ?? 'unknown'}
+              </Text>
+            </div>
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">Visibility</Text>
+              <Text className="truncate text-neutral-200">
+                {project.github.isPrivate ? 'Private' : 'Public'}
+              </Text>
+            </div>
           </div>
-
-          <div className="flex shrink-0 items-center gap-3">
-            <MachineConnectionIcon machine={machine} />
-            <MachineBatteryMeter machine={machine} />
-          </div>
-        </div>
-      </section>
-
-      <section className="grid gap-4 lg:grid-cols-2">
-        <Surface
-          variant="tertiary"
-          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-        >
-          <Text className="mb-3 block text-sm font-semibold text-neutral-100">Connection</Text>
-          <MachineDetailRow label="Status" value={machine.connector.status} />
-          <MachineDetailRow label="Service" value={machine.connector.serviceName ?? 'unknown'} />
-          <MachineDetailRow label="Last seen" value={formatOptionalTime(machine.connector.lastSeen)} />
-          <MachineDetailRow label="Origin" value={origin ?? 'unknown'} />
         </Surface>
 
         <Surface
           variant="tertiary"
           className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
         >
-          <Text className="mb-3 block text-sm font-semibold text-neutral-100">System</Text>
-          <MachineDetailRow label="OS" value={[machine.os?.family, machine.os?.version].filter(Boolean).join(' ') || 'unknown'} />
-          <MachineDetailRow label="Device" value={machine.kind || 'unknown'} />
-          <MachineDetailRow label="Profile" value={machine.profile ?? 'unknown'} />
-          <MachineDetailRow label="User" value={machine.primaryUser ?? machine.network.sshUser ?? 'unknown'} />
+          <Text className="block text-sm font-semibold text-neutral-100">Project config</Text>
+          <div className="mt-3 grid gap-2 text-sm">
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">Status</Text>
+              <Text className="truncate text-neutral-200">
+                {project.github.projectConfig.status}
+              </Text>
+            </div>
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">project.yaml</Text>
+              <Text className="truncate text-neutral-200">
+                {project.github.projectConfig.projectYaml ? 'Present' : 'Missing'}
+              </Text>
+            </div>
+            <div className="flex justify-between gap-3">
+              <Text className="text-neutral-500">template lock</Text>
+              <Text className="truncate text-neutral-200">
+                {project.github.projectConfig.templateLock ? 'Present' : 'Missing'}
+              </Text>
+            </div>
+          </div>
         </Surface>
       </section>
 
-      <MachineTerminalPanel machine={machine} />
+      <a
+        href={project.github.url}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex w-fit items-center gap-2 rounded-lg bg-neutral-900 px-3 py-2 text-sm font-medium text-neutral-100 transition hover:bg-neutral-800"
+      >
+        Open on GitHub
+        <ExternalLink className="size-4" />
+      </a>
 
-      <section>
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <Text className="text-sm font-semibold text-neutral-100">Projects on this machine</Text>
-          <Text className="text-xs text-neutral-500">{machineProjects.length}</Text>
-        </div>
+      <RepositoryActivityPanel repository={selectedRepository} />
+    </div>
+  );
+}
 
-        {machineProjects.length > 0 ? (
-          <div className="flex flex-col divide-y divide-neutral-900/80">
-            {machineProjects.map((project) => (
-              <button
-                key={project.id}
-                type="button"
-                title={project.rootPath}
-                onClick={() => onSelectProject(project.id)}
-                className="flex min-w-0 items-center justify-between gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
-              >
-                <span className="min-w-0">
-                  <Text className="block truncate text-sm font-medium text-neutral-100">
-                    {project.name}
-                  </Text>
-                  <Text className="block truncate font-mono text-xs text-neutral-500">
-                    {project.rootPath}
-                  </Text>
-                </span>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg bg-neutral-950/45 px-4 py-6">
-            <Text className="text-sm text-neutral-500">
-              No local projects reported by this machine yet.
+function LocalProjectView({
+  launcherError,
+  project,
+  selectedRepository,
+  selectedTargetPath,
+  targetLabel
+}: {
+  launcherError: string;
+  project: ProjectSpaceRecord;
+  selectedRepository?: ProjectSpaceRecord['github'];
+  selectedTargetPath: string;
+  targetLabel: string;
+}) {
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-4">
+      <section className="shrink-0 border-b border-neutral-800/70 pb-4">
+        <div className="flex min-w-0 flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <Text className="block text-[11px] font-medium text-neutral-500">{targetLabel}</Text>
+            <Text
+              title={selectedTargetPath}
+              className="mt-2 block truncate font-mono text-base font-medium text-neutral-50"
+            >
+              {selectedTargetPath}
             </Text>
           </div>
-        )}
+          <div className="min-w-[18rem] max-w-full">
+            <ProjectTemplateCheckPanel check={project.fullstackTemplate} />
+          </div>
+        </div>
+
+        {launcherError ? (
+          <Surface
+            variant="tertiary"
+            className="mt-3 rounded-lg border border-amber-400/20 bg-amber-500/8 px-4 py-3 text-sm text-amber-300"
+          >
+            {launcherError}
+          </Surface>
+        ) : null}
       </section>
+
+      <RepositoryActivityPanel repository={selectedRepository} />
+
+      <section className="grid gap-3 lg:grid-cols-2">
+        <Surface
+          variant="tertiary"
+          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <Play className="size-4 text-neutral-400" />
+            <Text className="text-sm font-semibold text-neutral-100">Actions</Text>
+          </div>
+          <Button variant="secondary" isDisabled={!project}>
+            Start developing a new feature
+          </Button>
+        </Surface>
+
+        <Surface
+          variant="tertiary"
+          className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <Server className="size-4 text-neutral-400" />
+            <Text className="text-sm font-semibold text-neutral-100">
+              Machines developing this project
+            </Text>
+          </div>
+          <div className="rounded-md border border-neutral-800 bg-neutral-950/50 px-3 py-2">
+            <Text className="block text-sm text-neutral-300">Local connector</Text>
+            <Text className="block truncate font-mono text-xs text-neutral-500">
+              {selectedTargetPath}
+            </Text>
+          </div>
+        </Surface>
+      </section>
+
+      <ProjectWorkspaceTools targetPath={selectedTargetPath} />
+      <ProjectCliCommandPanel project={project} targetPath={selectedTargetPath} />
+
+      <details className="group shrink-0 border-t border-neutral-800/70 pt-3">
+        <summary className="flex cursor-pointer list-none items-center gap-2 rounded-lg py-2 text-sm font-medium text-neutral-300 hover:text-neutral-100">
+          <ChevronDown
+            className="size-4 text-neutral-500 transition group-open:rotate-180"
+            strokeWidth={1.8}
+          />
+          Infrastructure and automation
+          <Text className="text-xs font-normal text-neutral-500">
+            connector, deploy, backup, scoped jobs
+          </Text>
+        </summary>
+        <div className="grid gap-3 pt-2">
+          <ProjectctlManifestPanel targetPath={selectedTargetPath} />
+          <ProjectOperationsPanel projectName={project.name} targetPath={selectedTargetPath} />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function EmptyProjectView({
+  onCreateProject
+}: {
+  onCreateProject(): void;
+}) {
+  return (
+    <div className="mx-auto flex h-full w-full max-w-6xl flex-col justify-center gap-4">
+      <Card variant="secondary" className="w-full border border-neutral-800/80 bg-neutral-950/70">
+        <Card.Header className="gap-3">
+          <Text className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">
+            No Projects
+          </Text>
+          <Card.Title className="text-2xl font-semibold tracking-tight text-neutral-50">
+            Nothing selected yet
+          </Card.Title>
+          <Card.Description className="text-base text-neutral-400">
+            Add projects to discover them.
+          </Card.Description>
+        </Card.Header>
+        <Card.Footer>
+          <Button variant="outline" onPress={onCreateProject}>
+            Select project
+          </Button>
+        </Card.Footer>
+      </Card>
+      <ProjectOperationsPanel projectName="project-space" targetPath="" />
     </div>
   );
 }
@@ -825,6 +333,7 @@ export function ProjectMainPanel({
   onOpenMachines,
   onOpenMachine,
   onOpenProjects,
+  onOpenRoot,
   onOpenSelectedTarget,
   onRefreshConnectorOverview,
   onRefreshGitHubCatalog,
@@ -838,12 +347,62 @@ export function ProjectMainPanel({
     () => resolveProjectRepository(project, githubCatalog),
     [githubCatalog, project]
   );
+  const mainBreadcrumbItems = useMemo<MainBreadcrumbItem[]>(() => {
+    if (mainView === 'root') {
+      return [];
+    }
+
+    const homeItem: MainBreadcrumbItem = {
+      label: 'Home',
+      onPress: onOpenRoot
+    };
+
+    if (mainView === 'machines') {
+      return [homeItem, { label: 'Machines' }];
+    }
+
+    if (mainView === 'machine') {
+      return [
+        homeItem,
+        { label: 'Machines', onPress: onOpenMachines },
+        { label: selectedMachine?.name ?? (selectedMachineId || 'Machine') }
+      ];
+    }
+
+    if (mainView === 'projects') {
+      return [homeItem, { label: 'Projects' }];
+    }
+
+    return [
+      homeItem,
+      { label: 'Projects', onPress: onOpenProjects },
+      { label: project?.name ?? 'Project' }
+    ];
+  }, [
+    mainView,
+    onOpenMachines,
+    onOpenProjects,
+    onOpenRoot,
+    project?.name,
+    selectedMachine?.name,
+    selectedMachineId
+  ]);
+  const handleMainBack = useCallback(() => {
+    if (mainView === 'machine') {
+      onOpenMachines();
+      return;
+    }
+
+    if (mainView === 'project') {
+      onOpenProjects();
+      return;
+    }
+
+    onOpenRoot();
+  }, [mainView, onOpenMachines, onOpenProjects, onOpenRoot]);
 
   return (
-    <Surface
-      variant="transparent"
-      className="flex min-h-0 flex-col rounded-none bg-app-panel"
-    >
+    <Surface variant="transparent" className="flex min-h-0 flex-col rounded-none bg-app-panel">
       <div
         className="relative flex h-14 items-center justify-between pr-4 sm:pr-6"
         style={{
@@ -857,31 +416,12 @@ export function ProjectMainPanel({
           }}
         />
 
-        <div className="relative flex min-w-0 items-center gap-3 leading-none">
-          <Text className="truncate text-[15px] font-semibold text-neutral-100">
-            {mainView === 'root'
-              ? 'Project Space'
-              : mainView === 'machines'
-              ? 'Machines'
-              : mainView === 'machine'
-                ? selectedMachine?.name ?? 'Machine'
-              : mainView === 'projects'
-                ? 'Projects'
-                : project?.name ?? 'No project selected'}
-          </Text>
-          {mainView === 'project' && project && project.kind !== 'github' ? (
-            <div className="hidden sm:block">
-              <Chip
-                color="default"
-                size="sm"
-                variant="tertiary"
-                className="shrink-0 text-neutral-400"
-              >
-                {selectedTargetName}
-              </Chip>
-            </div>
-          ) : null}
-        </div>
+        <ProjectHeaderTitle
+          mainView={mainView}
+          project={project}
+          selectedMachine={selectedMachine}
+          selectedTargetName={selectedTargetName}
+        />
 
         {mainView === 'project' && project?.kind !== 'github' ? (
           <div className="app-no-drag relative">
@@ -903,6 +443,11 @@ export function ProjectMainPanel({
           paddingBottom: hasBottomTabBar ? 'calc(6.75rem + env(safe-area-inset-bottom))' : '2rem'
         }}
       >
+        <MainBreadcrumbs
+          items={mainBreadcrumbItems}
+          onBack={mainView === 'root' ? undefined : handleMainBack}
+        />
+
         {mainView === 'machines' || mainView === 'projects' ? (
           <ProjectHomeOverview
             connector={connectorOverview}
@@ -926,7 +471,7 @@ export function ProjectMainPanel({
             projects={projects}
           />
         ) : mainView === 'root' ? (
-          <RootOverview
+          <ProjectRootOverview
             connector={connectorOverview}
             onOpenMachine={onOpenMachine}
             onOpenMachines={onOpenMachines}
@@ -935,199 +480,17 @@ export function ProjectMainPanel({
             projects={projects}
           />
         ) : project?.kind === 'github' && project.github ? (
-          <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-4">
-            <section className="shrink-0 border-b border-neutral-800/70 pb-4">
-              <Text className="block text-[11px] font-medium text-neutral-500">
-                GitHub repository
-              </Text>
-              <Text className="mt-2 block truncate text-xl font-semibold text-neutral-50">
-                {project.github.fullName}
-              </Text>
-              {project.github.description ? (
-                <Text className="mt-2 block text-sm text-neutral-500">
-                  {project.github.description}
-                </Text>
-              ) : null}
-            </section>
-
-            <section className="grid gap-3 sm:grid-cols-2">
-              <Surface
-                variant="tertiary"
-                className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-              >
-                <Text className="block text-sm font-semibold text-neutral-100">Repository</Text>
-                <div className="mt-3 grid gap-2 text-sm">
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">Owner</Text>
-                    <Text className="truncate text-neutral-200">{project.github.owner}</Text>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">Default branch</Text>
-                    <Text className="truncate text-neutral-200">
-                      {project.github.defaultBranch ?? 'unknown'}
-                    </Text>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">Visibility</Text>
-                    <Text className="truncate text-neutral-200">
-                      {project.github.isPrivate ? 'Private' : 'Public'}
-                    </Text>
-                  </div>
-                </div>
-              </Surface>
-
-              <Surface
-                variant="tertiary"
-                className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-              >
-                <Text className="block text-sm font-semibold text-neutral-100">
-                  Project config
-                </Text>
-                <div className="mt-3 grid gap-2 text-sm">
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">Status</Text>
-                    <Text className="truncate text-neutral-200">
-                      {project.github.projectConfig.status}
-                    </Text>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">project.yaml</Text>
-                    <Text className="truncate text-neutral-200">
-                      {project.github.projectConfig.projectYaml ? 'Present' : 'Missing'}
-                    </Text>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <Text className="text-neutral-500">template lock</Text>
-                    <Text className="truncate text-neutral-200">
-                      {project.github.projectConfig.templateLock ? 'Present' : 'Missing'}
-                    </Text>
-                  </div>
-                </div>
-              </Surface>
-            </section>
-
-            <a
-              href={project.github.url}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex w-fit items-center gap-2 rounded-lg bg-neutral-900 px-3 py-2 text-sm font-medium text-neutral-100 transition hover:bg-neutral-800"
-            >
-              Open on GitHub
-              <ExternalLink className="size-4" />
-            </a>
-
-            <RepositoryActivityPanel repository={selectedRepository} />
-          </div>
+          <GitHubProjectView project={project as ProjectSpaceRecord & { github: NonNullable<ProjectSpaceRecord['github']> }} selectedRepository={selectedRepository} />
         ) : project ? (
-          <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-4">
-            <section className="shrink-0 border-b border-neutral-800/70 pb-4">
-              <div className="flex min-w-0 flex-wrap items-start justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                  <Text className="block text-[11px] font-medium text-neutral-500">
-                    {targetLabel}
-                  </Text>
-                  <Text
-                    title={selectedTargetPath}
-                    className="mt-2 block truncate font-mono text-base font-medium text-neutral-50"
-                  >
-                    {selectedTargetPath}
-                  </Text>
-                </div>
-                <div className="min-w-[18rem] max-w-full">
-                  <ProjectTemplateCheckPanel check={project.fullstackTemplate} />
-                </div>
-              </div>
-
-              {launcherError ? (
-                <Surface
-                  variant="tertiary"
-                  className="mt-3 rounded-lg border border-amber-400/20 bg-amber-500/8 px-4 py-3 text-sm text-amber-300"
-                >
-                  {launcherError}
-                </Surface>
-              ) : null}
-            </section>
-
-            <RepositoryActivityPanel repository={selectedRepository} />
-
-            <section className="grid gap-3 lg:grid-cols-2">
-              <Surface
-                variant="tertiary"
-                className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-              >
-                <div className="mb-3 flex items-center gap-2">
-                  <Play className="size-4 text-neutral-400" />
-                  <Text className="text-sm font-semibold text-neutral-100">Actions</Text>
-                </div>
-                <Button variant="secondary" isDisabled={!project}>
-                  Start developing a new feature
-                </Button>
-              </Surface>
-
-              <Surface
-                variant="tertiary"
-                className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
-              >
-                <div className="mb-3 flex items-center gap-2">
-                  <Server className="size-4 text-neutral-400" />
-                  <Text className="text-sm font-semibold text-neutral-100">
-                    Machines developing this project
-                  </Text>
-                </div>
-                <div className="rounded-md border border-neutral-800 bg-neutral-950/50 px-3 py-2">
-                  <Text className="block text-sm text-neutral-300">Local connector</Text>
-                  <Text className="block truncate font-mono text-xs text-neutral-500">
-                    {selectedTargetPath}
-                  </Text>
-                </div>
-              </Surface>
-            </section>
-
-            <ProjectWorkspaceTools targetPath={selectedTargetPath} />
-            <ProjectCliCommandPanel project={project} targetPath={selectedTargetPath} />
-
-            <details className="group shrink-0 border-t border-neutral-800/70 pt-3">
-              <summary className="flex cursor-pointer list-none items-center gap-2 rounded-lg py-2 text-sm font-medium text-neutral-300 hover:text-neutral-100">
-                <ChevronDown
-                  className="size-4 text-neutral-500 transition group-open:rotate-180"
-                  strokeWidth={1.8}
-                />
-                Infrastructure and automation
-                <Text className="text-xs font-normal text-neutral-500">
-                  connector, deploy, backup, scoped jobs
-                </Text>
-              </summary>
-              <div className="grid gap-3 pt-2">
-                <ProjectctlManifestPanel targetPath={selectedTargetPath} />
-                <ProjectOperationsPanel projectName={project.name} targetPath={selectedTargetPath} />
-              </div>
-            </details>
-          </div>
+          <LocalProjectView
+            launcherError={launcherError}
+            project={project}
+            selectedRepository={selectedRepository}
+            selectedTargetPath={selectedTargetPath}
+            targetLabel={targetLabel}
+          />
         ) : (
-          <div className="mx-auto flex h-full w-full max-w-6xl flex-col justify-center gap-4">
-            <Card
-              variant="secondary"
-              className="w-full border border-neutral-800/80 bg-neutral-950/70"
-            >
-              <Card.Header className="gap-3">
-                <Text className="text-[11px] uppercase tracking-[0.18em] text-neutral-500">
-                  No Projects
-                </Text>
-                <Card.Title className="text-2xl font-semibold tracking-tight text-neutral-50">
-                  Nothing selected yet
-                </Card.Title>
-                <Card.Description className="text-base text-neutral-400">
-                  Add projects to discover them.
-                </Card.Description>
-              </Card.Header>
-              <Card.Footer>
-                <Button variant="outline" onPress={onCreateProject}>
-                  Select project
-                </Button>
-              </Card.Footer>
-            </Card>
-            <ProjectOperationsPanel projectName="project-space" targetPath="" />
-          </div>
+          <EmptyProjectView onCreateProject={onCreateProject} />
         )}
       </div>
     </Surface>

--- a/src/features/project-desktop/components/project-root-overview.tsx
+++ b/src/features/project-desktop/components/project-root-overview.tsx
@@ -1,0 +1,132 @@
+import type { ConnectorOverviewResult, ProjectSpaceRecord } from '@/shared/project-space-api';
+import { Button, Text } from '@/app/dotnaos-ui';
+import {
+  isMachineConnected,
+  MachineBatteryMeter,
+  MachineConnectionIcon,
+  MachineDeviceIcon,
+  MachineOsMark
+} from './machine-visuals';
+import {
+  formatRelativeTime,
+  getProjectTimestamp,
+  isVisibleProject,
+  machineSubtitle
+} from './project-main-model';
+
+export function ProjectRootOverview({
+  connector,
+  onOpenMachines,
+  onOpenMachine,
+  onOpenProjects,
+  onSelectProject,
+  projects
+}: {
+  connector: ConnectorOverviewResult;
+  onOpenMachines(): void;
+  onOpenMachine(machineId: string): void;
+  onOpenProjects(): void;
+  onSelectProject(projectId: string): void;
+  projects: ProjectSpaceRecord[];
+}) {
+  const connectedMachines = connector.machines.filter(isMachineConnected);
+  const recentProjects = projects
+    .filter(isVisibleProject)
+    .sort((left, right) => {
+      const timestampDelta = getProjectTimestamp(right) - getProjectTimestamp(left);
+
+      return timestampDelta || left.name.localeCompare(right.name);
+    })
+    .slice(0, 8);
+  const hasProjectTimestamps = recentProjects.some((project) => getProjectTimestamp(project) > 0);
+
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-8 pt-4">
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <Text className="text-sm font-semibold text-neutral-100">Running machines</Text>
+          <Button size="sm" variant="ghost" onPress={onOpenMachines}>
+            View all
+          </Button>
+        </div>
+
+        {connectedMachines.length > 0 ? (
+          <div className="divide-y divide-neutral-900/80">
+            {connectedMachines.map((machine) => (
+              <button
+                key={machine.id}
+                type="button"
+                onClick={() => onOpenMachine(machine.id)}
+                className="flex w-full min-w-0 items-center gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
+              >
+                <MachineConnectionIcon machine={machine} />
+                <MachineDeviceIcon machine={machine} />
+                <span className="min-w-0 flex-1">
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <Text className="block truncate text-sm font-medium text-neutral-100">
+                      {machine.name}
+                    </Text>
+                    <MachineOsMark machine={machine} />
+                  </span>
+                  <Text className="block truncate text-xs text-neutral-500">
+                    {machineSubtitle(machine) || machine.connector.status}
+                  </Text>
+                </span>
+                <MachineBatteryMeter compact machine={machine} />
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-neutral-950/45 px-4 py-5">
+            <Text className="text-sm text-neutral-500">No machines are currently connected.</Text>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <Text className="text-sm font-semibold text-neutral-100">
+            {hasProjectTimestamps ? 'Recent projects' : 'Projects'}
+          </Text>
+          <Button size="sm" variant="ghost" onPress={onOpenProjects}>
+            View all
+          </Button>
+        </div>
+
+        {recentProjects.length > 0 ? (
+          <div className="divide-y divide-neutral-900/80">
+            {recentProjects.map((entry) => {
+              const timestamp = getProjectTimestamp(entry);
+              const label = entry.github?.name ?? entry.name;
+              const sublabel = entry.github?.owner ?? (entry.kind === 'github' ? 'GitHub' : 'Local');
+              const relative = formatRelativeTime(timestamp);
+
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => onSelectProject(entry.id)}
+                  className="flex w-full min-w-0 items-center justify-between gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-neutral-900/50"
+                >
+                  <span className="min-w-0">
+                    <Text className="block truncate text-sm font-medium text-neutral-100">
+                      {label}
+                    </Text>
+                    <Text className="block truncate text-xs text-neutral-500">{sublabel}</Text>
+                  </span>
+                  {relative ? (
+                    <Text className="shrink-0 text-xs text-neutral-500">{relative}</Text>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-neutral-950/45 px-4 py-5">
+            <Text className="text-sm text-neutral-500">No projects discovered yet.</Text>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/project-sidebar-chrome.tsx
+++ b/src/features/project-desktop/components/project-sidebar-chrome.tsx
@@ -1,0 +1,79 @@
+import {
+  SearchField,
+  SearchFieldClearButton,
+  SearchFieldGroup,
+  SearchFieldInput,
+  SearchFieldSearchIcon,
+  Text
+} from '@/app/dotnaos-ui';
+import { ChevronRight } from 'lucide-react';
+
+export interface SidebarBreadcrumbItem {
+  label: string;
+  onPress?: () => void;
+}
+
+export function SidebarBreadcrumbs({ items }: { items: SidebarBreadcrumbItem[] }) {
+  return (
+    <nav
+      aria-label="Sidebar breadcrumb"
+      className="flex min-w-0 items-center gap-1 text-xs text-neutral-500"
+    >
+      {items.map((item, index) => {
+        const isCurrent = index === items.length - 1;
+        const content = (
+          <span className="block max-w-[13rem] truncate" title={item.label}>
+            {item.label}
+          </span>
+        );
+
+        return (
+          <span key={`${item.label}-${index}`} className="flex min-w-0 items-center gap-1">
+            {index > 0 ? (
+              <ChevronRight className="size-3 shrink-0 text-neutral-700" strokeWidth={1.8} />
+            ) : null}
+            {item.onPress && !isCurrent ? (
+              <button
+                type="button"
+                onClick={item.onPress}
+                className="min-w-0 rounded-md px-1 py-0.5 text-left transition hover:bg-neutral-800/70 hover:text-neutral-200"
+              >
+                {content}
+              </button>
+            ) : (
+              <Text
+                className={
+                  isCurrent ? 'min-w-0 px-1 py-0.5 text-neutral-300' : 'min-w-0 px-1 py-0.5'
+                }
+              >
+                {content}
+              </Text>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function SidebarSearch({
+  label,
+  onChange,
+  placeholder,
+  value
+}: {
+  label: string;
+  onChange(value: string): void;
+  placeholder: string;
+  value: string;
+}) {
+  return (
+    <SearchField aria-label={label} value={value} onChange={onChange} className="mb-3">
+      <SearchFieldGroup className="rounded-lg bg-neutral-900/90">
+        <SearchFieldSearchIcon />
+        <SearchFieldInput className="text-sm" placeholder={placeholder} spellCheck={false} />
+        <SearchFieldClearButton />
+      </SearchFieldGroup>
+    </SearchField>
+  );
+}

--- a/src/features/project-desktop/components/project-sidebar-pane.tsx
+++ b/src/features/project-desktop/components/project-sidebar-pane.tsx
@@ -2,15 +2,10 @@ import { useMemo, useState, type WheelEvent } from 'react';
 import {
   Button,
   ScrollShadow,
-  SearchField,
-  SearchFieldClearButton,
-  SearchFieldGroup,
-  SearchFieldInput,
-  SearchFieldSearchIcon,
   Surface,
   Text
 } from '@/app/dotnaos-ui';
-import { ChevronRight, FolderKanban, House, Server } from 'lucide-react';
+import { FolderKanban, House, Server } from 'lucide-react';
 import type {
   ConnectorOverviewResult,
   ExplorerTarget,
@@ -30,6 +25,11 @@ import {
   MachineOsMark
 } from './machine-visuals';
 import { SidebarContent } from './sidebar-content';
+import {
+  SidebarBreadcrumbs,
+  SidebarSearch,
+  type SidebarBreadcrumbItem
+} from './project-sidebar-chrome';
 import { SidebarProjectSelect } from './sidebar-project-select';
 import { SpacesDock } from './spaces-dock';
 
@@ -41,80 +41,6 @@ function isVisibleProject(project: ProjectSpaceRecord) {
 
 function matchesSearch(value: string, query: string) {
   return value.toLowerCase().includes(query.trim().toLowerCase());
-}
-
-interface SidebarBreadcrumbItem {
-  label: string;
-  onPress?: () => void;
-}
-
-function SidebarBreadcrumbs({ items }: { items: SidebarBreadcrumbItem[] }) {
-  return (
-    <nav
-      aria-label="Sidebar breadcrumb"
-      className="flex min-w-0 items-center gap-1 text-xs text-neutral-500"
-    >
-      {items.map((item, index) => {
-        const isCurrent = index === items.length - 1;
-        const content = (
-          <span className="block max-w-[13rem] truncate" title={item.label}>
-            {item.label}
-          </span>
-        );
-
-        return (
-          <span key={`${item.label}-${index}`} className="flex min-w-0 items-center gap-1">
-            {index > 0 ? (
-              <ChevronRight className="size-3 shrink-0 text-neutral-700" strokeWidth={1.8} />
-            ) : null}
-            {item.onPress && !isCurrent ? (
-              <button
-                type="button"
-                onClick={item.onPress}
-                className="min-w-0 rounded-md px-1 py-0.5 text-left transition hover:bg-neutral-800/70 hover:text-neutral-200"
-              >
-                {content}
-              </button>
-            ) : (
-              <Text
-                className={
-                  isCurrent ? 'min-w-0 px-1 py-0.5 text-neutral-300' : 'min-w-0 px-1 py-0.5'
-                }
-              >
-                {content}
-              </Text>
-            )}
-          </span>
-        );
-      })}
-    </nav>
-  );
-}
-
-function SidebarSearch({
-  label,
-  onChange,
-  placeholder,
-  value
-}: {
-  label: string;
-  onChange(value: string): void;
-  placeholder: string;
-  value: string;
-}) {
-  return (
-    <SearchField aria-label={label} value={value} onChange={onChange} className="mb-3">
-      <SearchFieldGroup className="rounded-lg bg-neutral-900/90">
-        <SearchFieldSearchIcon />
-        <SearchFieldInput
-          className="text-sm"
-          placeholder={placeholder}
-          spellCheck={false}
-        />
-        <SearchFieldClearButton />
-      </SearchFieldGroup>
-    </SearchField>
-  );
 }
 
 function formatMachineSubtitle(machine: MachineRecord) {

--- a/src/features/project-desktop/components/repository-activity-panel.tsx
+++ b/src/features/project-desktop/components/repository-activity-panel.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import type {
+  GitHubCatalogRepository,
+  GitHubRepositoryDetailsResult
+} from '@/shared/project-space-api';
+import { projectSpaceClient } from '@/api/project-space-client';
+import { Chip, Surface, Text } from '@/app/dotnaos-ui';
+import { GitBranch, ListChecks } from 'lucide-react';
+import { repositoryDetailsFallback } from './project-main-model';
+
+export function RepositoryActivityPanel({
+  repository
+}: {
+  repository?: GitHubCatalogRepository;
+}) {
+  const [details, setDetails] = useState<GitHubRepositoryDetailsResult>();
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!repository) {
+      setDetails(undefined);
+      return;
+    }
+
+    let canceled = false;
+
+    setError('');
+    setIsLoading(true);
+    projectSpaceClient
+      .getGitHubRepositoryDetails(repository.fullName)
+      .then((nextDetails) => {
+        if (!canceled) {
+          setDetails(nextDetails);
+        }
+      })
+      .catch((requestError) => {
+        if (!canceled) {
+          setError(
+            requestError instanceof Error
+              ? requestError.message
+              : 'Could not load repository details.'
+          );
+        }
+      })
+      .finally(() => {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [repository]);
+
+  if (!repository) {
+    return null;
+  }
+
+  const safeDetails = details ?? repositoryDetailsFallback('connected');
+  const issuesMessage =
+    error || safeDetails.message || (isLoading ? 'Loading repository details...' : '');
+
+  return (
+    <section className="grid gap-3 lg:grid-cols-2">
+      <Surface
+        variant="tertiary"
+        className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <GitBranch className="size-4 text-neutral-400" />
+            <Text className="text-sm font-semibold text-neutral-100">Branches</Text>
+          </div>
+          <Text className="text-xs text-neutral-500">{safeDetails.branches.length}</Text>
+        </div>
+        {safeDetails.branches.length > 0 ? (
+          <div className="flex max-h-64 flex-col overflow-auto">
+            {safeDetails.branches.map((branch) => (
+              <a
+                key={branch.name}
+                href={branch.url ?? repository.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex min-w-0 items-center justify-between gap-3 rounded-lg px-2 py-2 text-sm transition hover:bg-neutral-900/60"
+              >
+                <Text className="truncate text-neutral-200">{branch.name}</Text>
+                {branch.isDefault ? (
+                  <Chip size="sm" className="text-neutral-100">
+                    base
+                  </Chip>
+                ) : null}
+              </a>
+            ))}
+          </div>
+        ) : (
+          <Text className="text-sm text-neutral-500">
+            {issuesMessage || 'No branches loaded yet.'}
+          </Text>
+        )}
+      </Surface>
+
+      <Surface
+        variant="tertiary"
+        className="rounded-lg border border-neutral-800 bg-neutral-950/45 p-4"
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <ListChecks className="size-4 text-neutral-400" />
+            <Text className="text-sm font-semibold text-neutral-100">Issues</Text>
+          </div>
+          <Text className="text-xs text-neutral-500">{safeDetails.issues.length}</Text>
+        </div>
+        {safeDetails.issues.length > 0 ? (
+          <div className="flex max-h-64 flex-col overflow-auto">
+            {safeDetails.issues.map((issue) => (
+              <a
+                key={issue.number}
+                href={issue.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex min-w-0 items-start gap-3 rounded-lg px-2 py-2 transition hover:bg-neutral-900/60"
+              >
+                <Text className="shrink-0 text-xs text-neutral-500">#{issue.number}</Text>
+                <span className="min-w-0 flex-1">
+                  <Text className="block truncate text-sm font-medium text-neutral-100">
+                    {issue.title}
+                  </Text>
+                  {issue.author ? (
+                    <Text className="block truncate text-xs text-neutral-500">
+                      {issue.author}
+                    </Text>
+                  ) : null}
+                </span>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <Text className="text-sm text-neutral-500">{issuesMessage || 'No open issues.'}</Text>
+        )}
+      </Surface>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- split oversized Project Desktop components into focused files
- keep main panel, home overview, and sidebar pane under 700 lines
- preserve the recent breadcrumbs and list search behavior

## Verification
- bun run check
- go test ./...
- git diff --check
- production build with Clerk publishable key