### PR TITLE
Ignore runtime SSH directory in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .project
 tmp
 temp
+ssh
 node_modules
 **/node_modules
 **/.next


### PR DESCRIPTION
## Summary
- exclude the runtime ssh mount directory from Docker build context
- prevents VPS deploys from failing when the mounted SSH directory is root-owned

## Verification
- bun run check
- go test ./...
- git diff --check