### PR TITLE
[codex] Add module adoption command

### DIFF
--- a/cmd/project/adopt.go
+++ b/cmd/project/adopt.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/DotNaos/project-space/internal/projectvalidator"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 func newAdoptCommand() *cobra.Command {
 	dryRun := false
 	format := "pretty"
+	module := ""
 	reason := ""
 	waive := ""
 	yes := false
@@ -24,7 +26,10 @@ func newAdoptCommand() *cobra.Command {
 			if format != "pretty" && format != "json" {
 				return fmt.Errorf("unknown format %q; use pretty or json", format)
 			}
-			if format == "json" && waive != "" && !dryRun && !yes {
+			if module != "" && waive != "" {
+				return fmt.Errorf("use --module or --waive, not both")
+			}
+			if format == "json" && (waive != "" || module != "") && !dryRun && !yes {
 				return fmt.Errorf("use --dry-run or --yes with --format json")
 			}
 			target := "."
@@ -65,6 +70,33 @@ func newAdoptCommand() *cobra.Command {
 				}
 				return printAdoptionWaiverApplied(cmd, applied, format)
 			}
+			if module != "" {
+				plan, err := projectvalidator.AdoptModule(resolved, module, projectvalidator.AdoptionModuleOptions{})
+				if err != nil {
+					return err
+				}
+				if dryRun || !plan.WouldWrite {
+					return printAdoptionModulePlan(cmd, plan, projectvalidator.AdoptionModuleOptions{DryRun: true}, format)
+				}
+				if !yes {
+					if err := printAdoptionModulePlan(cmd, plan, projectvalidator.AdoptionModuleOptions{}, format); err != nil {
+						return err
+					}
+					confirmed, err := confirmApply(cmd)
+					if err != nil {
+						return err
+					}
+					if !confirmed {
+						printModuleCanceled(cmd, formatForModuleCancel(format))
+						return nil
+					}
+				}
+				applied, err := projectvalidator.AdoptModule(resolved, module, projectvalidator.AdoptionModuleOptions{Apply: true})
+				if err != nil {
+					return err
+				}
+				return printAdoptionModuleApplied(cmd, applied, format)
+			}
 			plan, err := projectvalidator.PlanAdoption(resolved)
 			if err != nil {
 				return err
@@ -74,11 +106,27 @@ func newAdoptCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show the adoption plan without writing changes")
 	cmd.Flags().StringVar(&format, "format", "pretty", "output format")
+	cmd.Flags().StringVar(&module, "module", "", "adopt a template module by adding only missing files")
 	cmd.Flags().StringVar(&reason, "reason", "", "reason for a waiver")
 	cmd.Flags().StringVar(&waive, "waive", "", "add a waiver for a path pattern")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply the adoption action without prompting")
 	must(cmd.RegisterFlagCompletionFunc("format", fixedValuesCompletion("pretty", "json")))
+	must(cmd.RegisterFlagCompletionFunc("module", adoptModuleFlagCompletion))
 	return cmd
+}
+
+func adoptModuleFlagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	modules, err := projectvalidator.ListModules(".")
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	matches := []string{}
+	for _, module := range modules {
+		if strings.HasPrefix(module, toComplete) {
+			matches = append(matches, module)
+		}
+	}
+	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
 func formatForModuleCancel(format string) string {
@@ -174,5 +222,71 @@ func printAdoptionWaiverApplied(cmd *cobra.Command, plan projectvalidator.Adopti
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Result: waiver added")
 	fmt.Fprintf(cmd.OutOrStdout(), "Lock: %s\n", plan.LockPath)
+	return nil
+}
+
+func printAdoptionModulePlan(cmd *cobra.Command, plan projectvalidator.AdoptionModulePlan, options projectvalidator.AdoptionModuleOptions, format string) error {
+	if format == "json" {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(plan)
+	}
+
+	mode := "dry-run"
+	if options.Apply {
+		mode = "apply"
+	} else if !options.DryRun {
+		mode = "confirm"
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Adoption module plan")
+	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", plan.ProjectRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "Module: %s\n", plan.Module)
+	fmt.Fprintf(cmd.OutOrStdout(), "Mode: %s\n\n", mode)
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Modules")
+	for _, module := range plan.AlreadyAdopted {
+		fmt.Fprintf(cmd.OutOrStdout(), "  = %s already adopted\n", module)
+	}
+	for _, module := range plan.ToAdopt {
+		fmt.Fprintf(cmd.OutOrStdout(), "  + %s\n", module)
+	}
+	if len(plan.AlreadyAdopted) == 0 && len(plan.ToAdopt) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no module changes")
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "\nFiles")
+	for _, file := range plan.Files {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s %-48s %s\n", moduleFileActionSymbol(file.Action), file.Path, file.Module)
+	}
+	if len(plan.Files) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "  no file changes")
+	}
+
+	if !plan.WouldWrite {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: no changes")
+		return nil
+	}
+	if options.DryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: dry run, no changes written")
+		return nil
+	}
+	if options.Apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nResult: applying")
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "\nResult: waiting for confirmation")
+	return nil
+}
+
+func printAdoptionModuleApplied(cmd *cobra.Command, plan projectvalidator.AdoptionModulePlan, format string) error {
+	if format == "json" {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(plan)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Result: module adopted")
+	if plan.LockPath != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Lock: %s\n", plan.LockPath)
+	}
 	return nil
 }

--- a/cmd/project/adopt_test.go
+++ b/cmd/project/adopt_test.go
@@ -75,6 +75,42 @@ func TestAdoptCommandAppliesWaiverAsJSON(t *testing.T) {
 	}
 }
 
+func TestAdoptCommandAppliesModuleAsJSON(t *testing.T) {
+	templateRoot := writeAdoptCommandTemplate(t)
+	projectRoot := filepath.Join(t.TempDir(), "demo-project")
+	if _, err := projectvalidator.InitProject(projectRoot, projectvalidator.InitOptions{TemplatePath: templateRoot}); err != nil {
+		t.Fatalf("InitProject returned error: %v", err)
+	}
+
+	cmd := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"adopt", projectRoot, "--module", "core.fullstack", "--yes", "--format", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("adopt module command returned error: %v\nstderr:\n%s", err, stderr.String())
+	}
+	var plan projectvalidator.AdoptionModulePlan
+	if err := json.Unmarshal(stdout.Bytes(), &plan); err != nil {
+		t.Fatalf("adopt module command did not print one JSON object: %v\n%s", err, stdout.String())
+	}
+	if plan.LockPath == "" {
+		t.Fatal("applied module adoption should report lock path")
+	}
+	if len(plan.Files) != 1 || plan.Files[0].Path != "README.md" {
+		t.Fatalf("files = %#v, want README.md add", plan.Files)
+	}
+	body, err := os.ReadFile(filepath.Join(projectRoot, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "# demo-project\n" {
+		t.Fatalf("README.md = %q, want rendered project name", string(body))
+	}
+}
+
 func writeAdoptCommandTemplate(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()

--- a/docs/project-cli.md
+++ b/docs/project-cli.md
@@ -80,6 +80,8 @@ If `[directory]` is omitted, the CLI uses the current directory.
 ```sh
 project adopt [directory]
 project adopt [directory] --format json
+project adopt [directory] --module <name>
+project adopt [directory] --module <name> --yes
 project adopt [directory] --waive <path-pattern> --reason <text>
 project adopt [directory] --waive <path-pattern> --reason <text> --yes
 ```
@@ -92,6 +94,11 @@ Files ignored by the template are otherwise left out of the adoption noise.
 
 `--waive` records tracked adoption debt in `.project/template.lock.yaml`.
 Waivers require a reason and cannot cover blocker files.
+
+`--module` adopts a template module for an existing project. It adds only
+missing template-owned files, never overwrites existing files, and records the
+module in `.project/template.lock.yaml`. Dependency modules are adopted with the
+requested module.
 
 ## Create The Project Token
 

--- a/internal/projectvalidator/adopt_module.go
+++ b/internal/projectvalidator/adopt_module.go
@@ -1,0 +1,148 @@
+package projectvalidator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func AdoptModule(projectRoot string, moduleName string, options AdoptionModuleOptions) (AdoptionModulePlan, error) {
+	root, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	lock, err := readTemplateLock(root)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	template, err := loadTemplate(root, lock)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	if len(template.Modules) == 0 {
+		return AdoptionModulePlan{}, fmt.Errorf("template %s does not define modules yet", template.Name)
+	}
+	if _, ok := template.Modules[moduleName]; !ok {
+		return AdoptionModulePlan{}, fmt.Errorf("unknown module %q", moduleName)
+	}
+
+	closure, err := moduleInstallClosure(template.Modules, moduleName)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	installed := installedModuleSet(lock.Modules)
+	plan := AdoptionModulePlan{ProjectRoot: root, Module: moduleName}
+	for _, module := range closure {
+		if installed[module] {
+			plan.AlreadyAdopted = append(plan.AlreadyAdopted, module)
+			continue
+		}
+		plan.ToAdopt = append(plan.ToAdopt, module)
+	}
+
+	files, err := adoptionModuleMissingFiles(root, template, lock, closure)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	plan.Files = files
+	plan.WouldWrite = len(plan.ToAdopt) > 0 || len(plan.Files) > 0
+	if !options.Apply || options.DryRun || !plan.WouldWrite {
+		return plan, nil
+	}
+
+	values, err := readTemplateValues(root)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	nextModules := append([]string{}, lock.Modules...)
+	nextModules = append(nextModules, plan.ToAdopt...)
+	nextModules = uniqueSortedModules(nextModules)
+	values, err = mergeTemplateValuesForModules(root, template, nextModules, values)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	if err := applyAdoptionModuleFiles(root, template, values, plan.Files); err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	if _, err := writeTemplateValues(root, values); err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	lock.Modules = nextModules
+	lockPath, err := writeTemplateLock(root, lock)
+	if err != nil {
+		return AdoptionModulePlan{}, err
+	}
+	plan.LockPath = lockPath
+	return plan, nil
+}
+
+func adoptionModuleMissingFiles(projectRoot string, template TemplateSpec, lock TemplateLock, modules []string) ([]AdoptionModuleFile, error) {
+	actualFiles := listProjectFiles(projectRoot)
+	modulePaths := []string{}
+	pathModule := map[string]string{}
+	for _, moduleName := range modules {
+		files, err := moduleTemplateFiles(template, moduleName)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range files {
+			if _, seen := pathModule[path]; seen {
+				continue
+			}
+			pathModule[path] = moduleName
+			modulePaths = append(modulePaths, path)
+		}
+	}
+	sort.Strings(modulePaths)
+
+	waivers, err := adoptionWaiversForFiles(template, lock, modulePaths)
+	if err != nil {
+		return nil, err
+	}
+	result := []AdoptionModuleFile{}
+	for _, path := range modulePaths {
+		if actualFiles[path] {
+			continue
+		}
+		if _, ok := waivers[path]; ok {
+			continue
+		}
+		result = append(result, AdoptionModuleFile{Action: "ADD", Module: pathModule[path], Path: path})
+	}
+	return result, nil
+}
+
+func applyAdoptionModuleFiles(projectRoot string, template TemplateSpec, values TemplateValues, files []AdoptionModuleFile) error {
+	for _, file := range files {
+		if file.Action != "ADD" {
+			continue
+		}
+		targetPath := filepath.Join(projectRoot, filepath.FromSlash(file.Path))
+		if stat, err := os.Stat(targetPath); err == nil && !stat.IsDir() {
+			return fmt.Errorf("adoption would overwrite existing project file %s; rerun the plan", file.Path)
+		} else if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		fileSpec, ok := template.Files[file.Path]
+		if !ok {
+			return fmt.Errorf("template file %s is not defined", file.Path)
+		}
+		sourcePath := filepath.Join(template.Root, filepath.FromSlash(fileSpec.TemplatePath))
+		body, err := os.ReadFile(sourcePath)
+		if err != nil {
+			return err
+		}
+		rendered, err := renderTemplateBody(body, values)
+		if err != nil {
+			return fmt.Errorf("%s: %w", file.Path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(targetPath, rendered, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/projectvalidator/adopt_test.go
+++ b/internal/projectvalidator/adopt_test.go
@@ -1,6 +1,7 @@
 package projectvalidator
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -108,6 +109,69 @@ func TestAddAdoptionWaiverRejectsBlocker(t *testing.T) {
 	}
 }
 
+func TestAdoptModuleAddsMissingFilesAndMarksLock(t *testing.T) {
+	templateRoot := writeAdoptionTestTemplate(t)
+	projectRoot := filepath.Join(t.TempDir(), "demo-project")
+	if _, err := InitProject(projectRoot, InitOptions{TemplatePath: templateRoot}); err != nil {
+		t.Fatalf("InitProject returned error: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(projectRoot, "package.json"), "{\"name\":\"custom\"}\n")
+
+	plan, err := AdoptModule(projectRoot, "core.fullstack", AdoptionModuleOptions{})
+	if err != nil {
+		t.Fatalf("AdoptModule returned error: %v", err)
+	}
+	if !plan.WouldWrite {
+		t.Fatal("module adoption should report writes")
+	}
+	if len(plan.Files) != 2 {
+		t.Fatalf("files length = %d, want 2", len(plan.Files))
+	}
+	assertAdoptionModuleFile(t, plan.Files, "README.md")
+	assertAdoptionModuleFile(t, plan.Files, "LICENSE")
+
+	applied, err := AdoptModule(projectRoot, "core.fullstack", AdoptionModuleOptions{Apply: true})
+	if err != nil {
+		t.Fatalf("AdoptModule apply returned error: %v", err)
+	}
+	if applied.LockPath == "" {
+		t.Fatal("applied module adoption should report lock path")
+	}
+	body, err := os.ReadFile(filepath.Join(projectRoot, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "{\"name\":\"custom\"}\n" {
+		t.Fatalf("package.json was overwritten: %q", string(body))
+	}
+	lock, err := readTemplateLock(projectRoot)
+	if err != nil {
+		t.Fatalf("readTemplateLock returned error: %v", err)
+	}
+	if len(lock.Modules) != 1 || lock.Modules[0] != "core.fullstack" {
+		t.Fatalf("lock modules = %#v, want core.fullstack", lock.Modules)
+	}
+	assertAdoptionFileContent(t, filepath.Join(projectRoot, "README.md"), "# demo-project\n")
+	assertAdoptionFileContent(t, filepath.Join(projectRoot, "LICENSE"), "MIT\n")
+}
+
+func TestAdoptModuleRespectsWaivedMissingFile(t *testing.T) {
+	templateRoot := writeAdoptionTestTemplate(t)
+	projectRoot := filepath.Join(t.TempDir(), "demo-project")
+	if _, err := InitProject(projectRoot, InitOptions{TemplatePath: templateRoot}); err != nil {
+		t.Fatalf("InitProject returned error: %v", err)
+	}
+	if _, err := AddAdoptionWaiver(projectRoot, "LICENSE", "license handled elsewhere", AdoptionWaiverOptions{Apply: true, Today: "2026-07-04"}); err != nil {
+		t.Fatalf("AddAdoptionWaiver returned error: %v", err)
+	}
+
+	plan, err := AdoptModule(projectRoot, "core.fullstack", AdoptionModuleOptions{})
+	if err != nil {
+		t.Fatalf("AdoptModule returned error: %v", err)
+	}
+	assertNoAdoptionModuleFile(t, plan.Files, "LICENSE")
+}
+
 func writeAdoptionTestTemplate(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -147,5 +211,38 @@ func assertNoAdoptionFile(t *testing.T, files []AdoptionFile, path string) {
 		if file.Path == path {
 			t.Fatalf("unexpected adoption file %s with state %s", path, file.State)
 		}
+	}
+}
+
+func assertAdoptionModuleFile(t *testing.T, files []AdoptionModuleFile, path string) {
+	t.Helper()
+	for _, file := range files {
+		if file.Path == path {
+			if file.Action != "ADD" {
+				t.Fatalf("%s action = %q, want ADD", path, file.Action)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing adoption module file %s", path)
+}
+
+func assertNoAdoptionModuleFile(t *testing.T, files []AdoptionModuleFile, path string) {
+	t.Helper()
+	for _, file := range files {
+		if file.Path == path {
+			t.Fatalf("unexpected adoption module file %s", path)
+		}
+	}
+}
+
+func assertAdoptionFileContent(t *testing.T, path string, want string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != want {
+		t.Fatalf("%s = %q, want %q", filepath.ToSlash(path), string(body), want)
 	}
 }

--- a/internal/projectvalidator/types.go
+++ b/internal/projectvalidator/types.go
@@ -212,6 +212,27 @@ type AdoptionWaiverPlan struct {
 	LockPath      string `json:"lockPath,omitempty"`
 }
 
+type AdoptionModuleOptions struct {
+	Apply  bool
+	DryRun bool
+}
+
+type AdoptionModulePlan struct {
+	ProjectRoot    string               `json:"projectRoot"`
+	Module         string               `json:"module"`
+	AlreadyAdopted []string             `json:"alreadyAdopted"`
+	ToAdopt        []string             `json:"toAdopt"`
+	Files          []AdoptionModuleFile `json:"files"`
+	WouldWrite     bool                 `json:"wouldWrite"`
+	LockPath       string               `json:"lockPath,omitempty"`
+}
+
+type AdoptionModuleFile struct {
+	Action string `json:"action"`
+	Module string `json:"module"`
+	Path   string `json:"path"`
+}
+
 type AdoptionCounts struct {
 	Match   int `json:"match"`
 	Slot    int `json:"slot"`


### PR DESCRIPTION
## Summary

Adds `project adopt --module <name>` for existing projects.

The command adopts a template module by adding only missing template-owned files, preserving existing project files, respecting waivers, and recording adopted modules in `.project/template.lock.yaml`.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check HEAD~1 HEAD`
- Dogfooded against `/Users/oli/projects/project-template` before commit: module adoption added missing files, preserved a custom `README.md`, and recorded `core.fullstack` in the lock.
- Template smoke passed with `--skip-secrets-doctor`; the full secret doctor check needs local access to the `projects` 1Password vault.
