### PR TITLE
Simplify docs command tables

### DIFF
--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -13,15 +13,15 @@ project [command]
 
 ## Commands
 
-| Command | Synonyms | Description |
-| --- | --- | --- |
-| `project create` | `project new` | Create and initialize a new project. |
-| `project init` | - | Initialize template state in an existing project. |
-| `project validate` | - | Validate a project against its local template snapshot. |
-| `project module` | - | List, inspect, add, and remove template modules. |
-| `project template` | - | Sync, update, and smoke-test template snapshots. |
-| `project deploy` | - | Deploy the project to the VPS using the project deploy contract. |
-| `project completion` | - | Generate shell completion scripts. |
+| Command | Description |
+| --- | --- |
+| `project create` | Create and initialize a new project. |
+| `project init` | Initialize template state in an existing project. |
+| `project validate` | Validate a project against its local template snapshot. |
+| `project module` | List, inspect, add, and remove template modules. |
+| `project template` | Sync, update, and smoke-test template snapshots. |
+| `project deploy` | Deploy the project to the VPS using the project deploy contract. |
+| `project completion` | Generate shell completion scripts. |
 
 ## Global Flags
 

--- a/apps/docs/content/docs/cli/modules.mdx
+++ b/apps/docs/content/docs/cli/modules.mdx
@@ -13,12 +13,12 @@ project module [command]
 
 Available commands:
 
-| Command | Synonyms | Description |
-| --- | --- | --- |
-| `project module list` | - | List available and installed modules. |
-| `project module show` | - | Show details for one module. |
-| `project module add` | `project module install` | Add a module to the project. |
-| `project module remove` | - | Remove a module from the project. |
+| Command | Description |
+| --- | --- |
+| `project module list` | List available and installed modules. |
+| `project module show` | Show details for one module. |
+| `project module add` | Add a module to the project. |
+| `project module remove` | Remove a module from the project. |
 
 ## `project module list`
 


### PR DESCRIPTION
## Summary\n- remove Synonyms from command overview tables\n- keep command aliases documented on detail pages and flag aliases unchanged\n\n## Verification\n- bun run docs:build\n- Browser check on /docs/cli mobile: Commands table headers are Command + Description\n- Browser check on /docs/cli/modules: Available commands table headers are Command + Description