### PR TITLE
Show short command names in docs tables

### DIFF
--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -13,15 +13,15 @@ project [command]
 
 ## Commands
 
-| Command | Description |
-| --- | --- |
-| `project create` | Create and initialize a new project. |
-| `project init` | Initialize template state in an existing project. |
-| `project validate` | Validate a project against its local template snapshot. |
-| `project module` | List, inspect, add, and remove template modules. |
-| `project template` | Sync, update, and smoke-test template snapshots. |
-| `project deploy` | Deploy the project to the VPS using the project deploy contract. |
-| `project completion` | Generate shell completion scripts. |
+| Command | Synonyms | Description |
+| --- | --- | --- |
+| `create` | `new` | Create and initialize a new project. |
+| `init` | - | Initialize template state in an existing project. |
+| `validate` | - | Validate a project against its local template snapshot. |
+| `module` | - | List, inspect, add, and remove template modules. |
+| `template` | - | Sync, update, and smoke-test template snapshots. |
+| `deploy` | - | Deploy the project to the VPS using the project deploy contract. |
+| `completion` | - | Generate shell completion scripts. |
 
 ## Global Flags
 

--- a/apps/docs/content/docs/cli/modules.mdx
+++ b/apps/docs/content/docs/cli/modules.mdx
@@ -13,12 +13,12 @@ project module [command]
 
 Available commands:
 
-| Command | Description |
-| --- | --- |
-| `project module list` | List available and installed modules. |
-| `project module show` | Show details for one module. |
-| `project module add` | Add a module to the project. |
-| `project module remove` | Remove a module from the project. |
+| Command | Synonyms | Description |
+| --- | --- | --- |
+| `list` | - | List available and installed modules. |
+| `show` | - | Show details for one module. |
+| `add` | `install` | Add a module to the project. |
+| `remove` | - | Remove a module from the project. |
 
 ## `project module list`
 


### PR DESCRIPTION
## Summary
- keep the command table synonym columns
- remove the repeated project prefix from command and synonym cells
- apply the same shorter style to module command summaries

## Verification
- bun run docs:build
- browser-checked /docs/cli and /docs/cli/modules locally at mobile width