### PR TITLE
Route git history through backend API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,12 @@
+## Project Space Deployments
+
+- Do not deploy Project Space to Vercel. Vercel is not the production target for this app.
+- Production deploys for Project Space go to the VPS through the Project CLI: `./bin/project deploy --env prod`.
+- The live Project Space URL is `https://projects.os-home.net`.
+- After deploying, verify the VPS state with `./bin/project deploy status --env prod --format json`, confirm the remote checkout commit under `/opt/platform/apps/project-space`, and open the live `projects.os-home.net` page in the browser.
+- If deployment secrets are needed, use the 1Password references in `deploy/deploy.yaml`; never paste secret values into chat, source files, or logs.
+- Do not treat a successful Vercel preview or production deployment as evidence that Project Space is live. Only the VPS deploy and `projects.os-home.net` verification count.
+
 - Use HeroUI React documentation from https://v3.heroui.com/react/llms.txt
 
 <!-- HEROUI-REACT-AGENTS-MD-START -->

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,7 +21,7 @@ FROM oven/bun:1 AS runner
 
 WORKDIR /workspace
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssh-client \
+  && apt-get install -y --no-install-recommends git openssh-client \
   && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
 ENV PROJECT_SPACE_HOST=0.0.0.0

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -15,11 +15,13 @@ services:
       PROJECT_SPACE_ALLOWED_EMAILS: ${PROJECT_SPACE_ALLOWED_EMAILS:-}
       PROJECT_SPACE_ALLOWED_GITHUB_LOGINS: ${PROJECT_SPACE_ALLOWED_GITHUB_LOGINS:-}
       PROJECT_SPACE_AUTH_DISABLED: ${PROJECT_SPACE_AUTH_DISABLED:-}
+      PROJECT_SPACE_BACKEND_REPO_PATH: ${PROJECT_SPACE_BACKEND_REPO_PATH:-/workspace/backend-repo}
       PROJECT_CONNECTOR_REGISTRATION_TOKEN: ${PROJECT_CONNECTOR_REGISTRATION_TOKEN:-}
       PROJECT_CONNECTOR_SERVICE_NAME: ${PROJECT_COMPOSE_NAME:-project-space-prod}-web
     image: project-space-web:local
     restart: unless-stopped
     volumes:
+      - ..:/workspace/backend-repo:ro
       - ../ssh:/root/.ssh:ro
 
   docs:

--- a/server/local-git-client.ts
+++ b/server/local-git-client.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { runCommand } from './local-command-runner';
@@ -6,10 +7,16 @@ import type {
   GitCommitRequest,
   GitDiffRequest,
   GitDiffResult,
+  GitHistoryCommit,
+  GitHistoryRequest,
+  GitHistoryResult,
   GitStageRequest,
   GitStatusEntry,
   GitStatusResult
 } from '../src/shared/project-space-api';
+
+const FIELD_SEPARATOR = String.fromCharCode(31);
+const MAX_HISTORY_LIMIT = 1000;
 
 function parseStatusEntry(line: string): GitStatusEntry | null {
   if (line.length < 4) {
@@ -36,6 +43,84 @@ async function resolveGitRoot(cwd: string) {
   const output = await git(['rev-parse', '--show-toplevel'], cwd);
 
   return output.stdout.trim();
+}
+
+function parseGitHistory(stdout: string): GitHistoryCommit[] {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [hash, parents, author, date, refs, ...subjectParts] = line.split(FIELD_SEPARATOR);
+
+      return {
+        author: author ?? '',
+        date: date ?? '',
+        hash: hash ?? '',
+        parents: (parents ?? '').split(' ').filter(Boolean),
+        refs: (refs ?? '')
+          .split(',')
+          .map((ref) => ref.trim())
+          .filter(Boolean),
+        subject: subjectParts.join(FIELD_SEPARATOR) || ''
+      };
+    })
+    .filter((commit) => commit.hash);
+}
+
+function normalizeRepositoryFullName(value: string | undefined) {
+  return value?.trim().replace(/\.git$/, '').toLowerCase();
+}
+
+function parseRepositoryFullNameFromRemote(remoteUrl: string) {
+  const trimmed = remoteUrl.trim().replace(/\.git$/, '');
+  const githubMatch = trimmed.match(/github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/]+)$/i);
+
+  if (!githubMatch?.groups) {
+    return undefined;
+  }
+
+  return `${githubMatch.groups.owner}/${githubMatch.groups.repo}`;
+}
+
+async function repositoryMatches(root: string, repositoryFullName: string | undefined) {
+  const expected = normalizeRepositoryFullName(repositoryFullName);
+
+  if (!expected) {
+    return true;
+  }
+
+  const remoteOutput = await git(['remote', 'get-url', 'origin'], root).catch(() => ({
+    stdout: '',
+    stderr: ''
+  }));
+  const actual = normalizeRepositoryFullName(
+    parseRepositoryFullNameFromRemote(remoteOutput.stdout)
+  );
+
+  return actual === expected;
+}
+
+function getBackendRepositoryCandidates(requestCwd: string | undefined) {
+  return Array.from(
+    new Set(
+      [
+        requestCwd,
+        process.env.PROJECT_SPACE_BACKEND_REPO_PATH,
+        process.cwd()
+      ].filter((candidate): candidate is string => Boolean(candidate?.trim()))
+    )
+  );
+}
+
+function normalizeHistoryLimit(limit: number | undefined) {
+  const numericLimit = Math.trunc(limit ?? 300);
+
+  if (!Number.isFinite(numericLimit)) {
+    return 300;
+  }
+
+  return Math.min(Math.max(numericLimit, 1), MAX_HISTORY_LIMIT);
 }
 
 export async function getGitStatus(cwd: string): Promise<GitStatusResult> {
@@ -107,6 +192,71 @@ export async function getGitDiff(request: GitDiffRequest): Promise<GitDiffResult
     diff: output.stdout || output.stderr || 'No diff for this selection.',
     path: request.path,
     staged: Boolean(request.staged)
+  };
+}
+
+export async function getGitHistory(request: GitHistoryRequest): Promise<GitHistoryResult> {
+  const limit = normalizeHistoryLimit(request.limit);
+  const candidates = getBackendRepositoryCandidates(request.cwd);
+  const fallbackCwd = request.cwd ? resolve(request.cwd) : resolve(process.cwd());
+
+  for (const candidate of candidates) {
+    const resolvedCwd = resolve(candidate);
+
+    if (!existsSync(resolvedCwd)) {
+      continue;
+    }
+
+    const status = await getGitStatus(resolvedCwd);
+
+    if (!status.isRepository) {
+      continue;
+    }
+
+    if (!(await repositoryMatches(status.repositoryRoot, request.repositoryFullName))) {
+      continue;
+    }
+
+    try {
+      const output = await git(
+        [
+          'log',
+          '--all',
+          '--date-order',
+          '-n',
+          String(limit),
+          '--date=short',
+          '--pretty=format:%H%x1f%P%x1f%an%x1f%ad%x1f%D%x1f%s'
+        ],
+        status.repositoryRoot
+      );
+
+      return {
+        commits: parseGitHistory(output.stdout),
+        cwd: resolvedCwd,
+        isRepository: true,
+        repositoryRoot: status.repositoryRoot,
+        stderr: output.stderr
+      };
+    } catch (error) {
+      return {
+        commits: [],
+        cwd: resolvedCwd,
+        isRepository: true,
+        message: error instanceof Error ? error.message : 'Could not read git history.',
+        repositoryRoot: status.repositoryRoot
+      };
+    }
+  }
+
+  return {
+    commits: [],
+    cwd: fallbackCwd,
+    isRepository: false,
+    message: request.repositoryFullName
+      ? `No backend git repository was found for ${request.repositoryFullName}.`
+      : 'No backend git repository was found.',
+    repositoryRoot: fallbackCwd
   };
 }
 

--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -15,6 +15,7 @@ import {
 import {
   commitGitChanges,
   getGitDiff,
+  getGitHistory,
   getGitStatus,
   stageGitPaths,
   unstageGitPaths
@@ -657,6 +658,9 @@ export function createLocalProjectSpaceBackend(
     },
     async getGitDiff(request) {
       return getGitDiff(request);
+    },
+    async getGitHistory(request) {
+      return getGitHistory(request);
     },
     async getGitStatus(cwd: string) {
       return getGitStatus(cwd);

--- a/server/project-space-http.ts
+++ b/server/project-space-http.ts
@@ -27,6 +27,7 @@ import type {
   ProjectCliCommandRequest,
   GitCommitRequest,
   GitDiffRequest,
+  GitHistoryRequest,
   GitStageRequest,
   ProjectDeployRequest,
   ProjectDirectorySelection,
@@ -497,6 +498,12 @@ function createApiHandler(backend: ProjectSpaceBackend) {
         }
 
         writeJson(response, 200, await backend.getGitStatus(cwd));
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/git/history') {
+        const payload = await readJson<GitHistoryRequest>(request);
+        writeJson(response, 200, await backend.getGitHistory(payload));
         return true;
       }
 

--- a/src/api/project-space-client.ts
+++ b/src/api/project-space-client.ts
@@ -8,6 +8,8 @@ import type {
   GitCommitRequest,
   GitDiffRequest,
   GitDiffResult,
+  GitHistoryRequest,
+  GitHistoryResult,
   GitHubCatalogResult,
   GitHubRepositoryDetailsResult,
   GitHubOAuthDevicePollRequest,
@@ -185,6 +187,13 @@ class HttpProjectSpaceClient implements ProjectSpaceBackend {
 
   getGitDiff(request: GitDiffRequest): Promise<GitDiffResult> {
     return this.request('/api/git/diff', {
+      body: JSON.stringify(request),
+      method: 'POST'
+    });
+  }
+
+  getGitHistory(request: GitHistoryRequest): Promise<GitHistoryResult> {
+    return this.request('/api/git/history', {
       body: JSON.stringify(request),
       method: 'POST'
     });

--- a/src/features/project-desktop/components/git-graph-panel.tsx
+++ b/src/features/project-desktop/components/git-graph-panel.tsx
@@ -3,11 +3,11 @@ import { GitCommitHorizontal, GitPullRequest, RefreshCw, Tag } from 'lucide-reac
 import { Button, Chip, Surface, Text, Tooltip } from '@/app/dotnaos-ui';
 import { projectSpaceClient } from '@/api/project-space-client';
 import { cn } from '@/lib/utils';
+import type { GitHistoryCommit } from '@/shared/project-space-api';
 
 const COMMIT_LIMIT = 300;
 const LANE_WIDTH = 14;
 const ROW_HEIGHT = 32;
-const FIELD_SEPARATOR = String.fromCharCode(31);
 
 const lanePalette = [
   '#0085d9',
@@ -20,14 +20,7 @@ const lanePalette = [
   '#e138e8'
 ];
 
-interface GraphCommit {
-  author: string;
-  date: string;
-  hash: string;
-  parents: string[];
-  refs: string[];
-  subject: string;
-}
+type GraphCommit = GitHistoryCommit;
 
 interface RowSegment {
   color: string;
@@ -41,29 +34,6 @@ interface GraphRow {
   column: number;
   commit: GraphCommit;
   segments: RowSegment[];
-}
-
-function parseGitLog(stdout: string): GraphCommit[] {
-  return stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [hash, parents, author, date, refs, ...subjectParts] = line.split(FIELD_SEPARATOR);
-
-      return {
-        author: author ?? '',
-        date: date ?? '',
-        hash: hash ?? '',
-        parents: (parents ?? '').split(' ').filter(Boolean),
-        refs: (refs ?? '')
-          .split(',')
-          .map((ref) => ref.trim())
-          .filter(Boolean),
-        subject: subjectParts.join(FIELD_SEPARATOR) || ''
-      };
-    })
-    .filter((commit) => commit.hash);
 }
 
 interface Lane {
@@ -283,7 +253,13 @@ function CommitDotTooltip({
   );
 }
 
-export function GitGraphPanel({ targetPath }: { targetPath: string }) {
+export function GitGraphPanel({
+  repositoryFullName,
+  targetPath
+}: {
+  repositoryFullName?: string;
+  targetPath: string;
+}) {
   const [commits, setCommits] = useState<GraphCommit[]>([]);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -297,18 +273,20 @@ export function GitGraphPanel({ targetPath }: { targetPath: string }) {
     setIsLoading(true);
     setError('');
     try {
-      const result = await projectSpaceClient.runTerminalCommand({
-        command: `git log --all --date-order -n ${COMMIT_LIMIT} --date=short --pretty=format:%H%x1f%P%x1f%an%x1f%ad%x1f%D%x1f%s`,
-        cwd: targetPath
+      const result = await projectSpaceClient.getGitHistory({
+        cwd: targetPath,
+        limit: COMMIT_LIMIT,
+        repositoryFullName
       });
 
-      if (result.exitCode !== 0) {
+      if (!result.isRepository) {
         setCommits([]);
-        setError(result.stderr.trim() || 'Could not read the git history.');
+        setError(result.message ?? 'Could not read the git history.');
         return;
       }
 
-      setCommits(parseGitLog(result.stdout));
+      setCommits(result.commits);
+      setError(result.message ?? '');
     } catch (requestError) {
       setCommits([]);
       setError(
@@ -321,7 +299,7 @@ export function GitGraphPanel({ targetPath }: { targetPath: string }) {
 
   useEffect(() => {
     void refresh();
-  }, [targetPath]);
+  }, [repositoryFullName, targetPath]);
 
   const { maxLanes, rows } = useMemo(() => layoutGraph(commits), [commits]);
   const graphWidth = maxLanes * LANE_WIDTH;

--- a/src/features/project-desktop/components/project-detail.tsx
+++ b/src/features/project-desktop/components/project-detail.tsx
@@ -596,7 +596,12 @@ export function ProjectDetail({
           />
         ) : null}
 
-        {tab === 'history' ? <GitGraphPanel targetPath={selectedTargetPath} /> : null}
+        {tab === 'history' ? (
+          <GitGraphPanel
+            repositoryFullName={selectedRepository?.fullName}
+            targetPath={selectedTargetPath}
+          />
+        ) : null}
 
         {tab === 'issues' ? (
           <ProjectIssueDetailPanel

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -646,6 +646,30 @@ export interface ScopeDevboxStartRequest {
   writableFiles: string[];
 }
 
+export interface GitHistoryRequest {
+  cwd?: string;
+  limit?: number;
+  repositoryFullName?: string;
+}
+
+export interface GitHistoryCommit {
+  author: string;
+  date: string;
+  hash: string;
+  parents: string[];
+  refs: string[];
+  subject: string;
+}
+
+export interface GitHistoryResult {
+  commits: GitHistoryCommit[];
+  cwd: string;
+  isRepository: boolean;
+  message?: string;
+  repositoryRoot: string;
+  stderr?: string;
+}
+
 export interface ProjectSpaceBackend {
   getAppMeta(): Promise<AppMeta>;
   getCodexStatus(): Promise<CodexStatusResult>;
@@ -654,6 +678,7 @@ export interface ProjectSpaceBackend {
   runProjectCliCommand(request: ProjectCliCommandRequest): Promise<ProjectCliCommandResult>;
   getGitHubCatalog(): Promise<GitHubCatalogResult>;
   getGitDiff(request: GitDiffRequest): Promise<GitDiffResult>;
+  getGitHistory(request: GitHistoryRequest): Promise<GitHistoryResult>;
   getGitStatus(cwd: string): Promise<GitStatusResult>;
   getPlatformOverview(): Promise<PlatformOverviewResult>;
   loadLauncherAppIcon(appId: string): Promise<string | undefined>;


### PR DESCRIPTION
## Summary
- add a typed backend git history API for the History tab
- stop using the terminal runner for the commit graph
- give the VPS web container git and read-only access to the backend checkout
- document that Project Space deploys only to the VPS, not Vercel

## Verification
- bun run check
- bun run build
- local /api/git/history returns real commits
- local History tab shows 91 commits with no route or shell errors