### PR TITLE
Mark backend repo safe for git history

### DIFF
--- a/server/local-git-client.ts
+++ b/server/local-git-client.ts
@@ -35,8 +35,29 @@ function parseStatusEntry(line: string): GitStatusEntry | null {
   };
 }
 
+function resolveConfiguredBackendRepositoryPath() {
+  return process.env.PROJECT_SPACE_BACKEND_REPO_PATH
+    ? resolve(process.env.PROJECT_SPACE_BACKEND_REPO_PATH)
+    : undefined;
+}
+
+function gitArgsForCwd(args: string[], cwd: string) {
+  const backendRepositoryPath = resolveConfiguredBackendRepositoryPath();
+  const resolvedCwd = resolve(cwd);
+
+  if (
+    backendRepositoryPath &&
+    (resolvedCwd === backendRepositoryPath ||
+      resolvedCwd.startsWith(`${backendRepositoryPath}/`))
+  ) {
+    return ['-c', `safe.directory=${backendRepositoryPath}`, ...args];
+  }
+
+  return args;
+}
+
 async function git(args: string[], cwd: string) {
-  return runCommand('git', args, cwd);
+  return runCommand('git', gitArgsForCwd(args, cwd), cwd);
 }
 
 async function resolveGitRoot(cwd: string) {


### PR DESCRIPTION
## Summary
- pass Git safe.directory for the mounted backend repository
- fixes the VPS container reading /workspace/backend-repo after the read-only mount

## Verification
- PROJECT_SPACE_BACKEND_REPO_PATH fallback returns git history locally
- bun run check
- bun run build