### PR TITLE
Add issue board and list views

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -22,9 +22,10 @@
       "runtimeExecutable": "sh",
       "runtimeArgs": [
         "-c",
-        "VITE_PROJECT_SPACE_AUTH_DISABLED=1 VITE_PROJECT_SPACE_API_BASE_URL=http://127.0.0.1:4174 pnpm exec vite --host 127.0.0.1 --port 5175"
+        "VITE_PROJECT_SPACE_AUTH_DISABLED=1 VITE_PROJECT_SPACE_API_BASE_URL=http://127.0.0.1:4174 pnpm exec vite --host 127.0.0.1 --port ${PORT:-5175}"
       ],
-      "port": 5175
+      "port": 5175,
+      "autoPort": true
     }
   ]
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -51,6 +51,40 @@ label[for]:hover {
   box-sizing: border-box;
 }
 
+@keyframes issue-rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+}
+
+.issue-rise-in {
+  animation: issue-rise-in 0.3s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+body.issue-dragging,
+body.issue-dragging * {
+  cursor: grabbing !important;
+}
+
+body.issue-dragging {
+  user-select: none;
+}
+
+@keyframes issue-drag-pop {
+  from {
+    transform: scale(1) rotate(0deg);
+  }
+
+  to {
+    transform: scale(1.03) rotate(1.5deg);
+  }
+}
+
+.issue-drag-preview {
+  animation: issue-drag-pop 0.16s ease-out both;
+}
+
 .app-drag {
   -webkit-app-region: drag;
 }

--- a/src/features/project-desktop/components/issue-board-model.ts
+++ b/src/features/project-desktop/components/issue-board-model.ts
@@ -1,0 +1,271 @@
+import type { GitHubIssueRecord } from '@/shared/project-space-api';
+import { formatRelativeTime } from './project-main-model';
+
+export type IssueColumnId = 'backlog' | 'blocked' | 'in-progress' | 'ready';
+export type IssueViewMode = 'board' | 'list';
+
+export interface IssueColumnDefinition {
+  dotClass: string;
+  dropClass: string;
+  hint: string;
+  id: IssueColumnId;
+  label: string;
+}
+
+export const issueColumns: IssueColumnDefinition[] = [
+  {
+    dotClass: 'bg-emerald-400',
+    dropClass: 'border-emerald-400/50 bg-emerald-400/[0.04]',
+    hint: 'Cleared to pick up',
+    id: 'ready',
+    label: 'Ready'
+  },
+  {
+    dotClass: 'bg-sky-400',
+    dropClass: 'border-sky-400/50 bg-sky-400/[0.04]',
+    hint: 'Being worked on',
+    id: 'in-progress',
+    label: 'In progress'
+  },
+  {
+    dotClass: 'bg-rose-400',
+    dropClass: 'border-rose-400/50 bg-rose-400/[0.04]',
+    hint: 'Waiting on something',
+    id: 'blocked',
+    label: 'Blocked'
+  },
+  {
+    dotClass: 'bg-neutral-500',
+    dropClass: 'border-neutral-500/60 bg-neutral-500/[0.04]',
+    hint: 'Not scheduled yet',
+    id: 'backlog',
+    label: 'Backlog'
+  }
+];
+
+export function issueColumnById(columnId: IssueColumnId) {
+  return issueColumns.find((column) => column.id === columnId) ?? issueColumns[3];
+}
+
+export type IssueColumnOverrides = Record<number, IssueColumnId>;
+
+function derivedIssueColumn(issue: GitHubIssueRecord, index: number): IssueColumnId {
+  const text = `${issue.title} ${issue.labels.join(' ')}`.toLowerCase();
+
+  if (text.includes('blocked') || text.includes('blocker') || text.includes('waiting')) {
+    return 'blocked';
+  }
+
+  if (text.includes('in progress') || text.includes('wip') || text.includes('doing')) {
+    return 'in-progress';
+  }
+
+  if (text.includes('ready') || index < 4) {
+    return 'ready';
+  }
+
+  return 'backlog';
+}
+
+export function resolveIssueColumn(
+  issue: GitHubIssueRecord,
+  index: number,
+  overrides: IssueColumnOverrides
+): IssueColumnId {
+  return overrides[issue.number] ?? derivedIssueColumn(issue, index);
+}
+
+export function groupIssuesByColumn(
+  issues: GitHubIssueRecord[],
+  overrides: IssueColumnOverrides
+) {
+  const groups: Record<IssueColumnId, GitHubIssueRecord[]> = {
+    backlog: [],
+    blocked: [],
+    'in-progress': [],
+    ready: []
+  };
+
+  issues.forEach((issue, index) => {
+    groups[resolveIssueColumn(issue, index, overrides)].push(issue);
+  });
+
+  return groups;
+}
+
+const columnIds = new Set<string>(issueColumns.map((column) => column.id));
+
+function boardStorageKey(repoFullName: string) {
+  return `project-space:issue-board:v1:${repoFullName}`;
+}
+
+export function loadIssueColumnOverrides(repoFullName?: string): IssueColumnOverrides {
+  if (!repoFullName) {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(boardStorageKey(repoFullName));
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+
+    const overrides: IssueColumnOverrides = {};
+
+    for (const [key, value] of Object.entries(parsed)) {
+      const issueNumber = Number(key);
+
+      if (Number.isInteger(issueNumber) && typeof value === 'string' && columnIds.has(value)) {
+        overrides[issueNumber] = value as IssueColumnId;
+      }
+    }
+
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
+export function saveIssueColumnOverrides(
+  repoFullName: string | undefined,
+  overrides: IssueColumnOverrides
+) {
+  if (!repoFullName) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(boardStorageKey(repoFullName), JSON.stringify(overrides));
+  } catch {
+    // Persisting the board layout is best-effort.
+  }
+}
+
+const hiddenColumnsStorageKey = 'project-space:issue-board-hidden-columns:v1';
+
+export function loadHiddenIssueColumns(): Set<IssueColumnId> {
+  try {
+    const raw = window.localStorage.getItem(hiddenColumnsStorageKey);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+
+    if (!Array.isArray(parsed)) {
+      return new Set();
+    }
+
+    return new Set(
+      parsed.filter(
+        (value): value is IssueColumnId => typeof value === 'string' && columnIds.has(value)
+      )
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveHiddenIssueColumns(hidden: ReadonlySet<IssueColumnId>) {
+  try {
+    window.localStorage.setItem(hiddenColumnsStorageKey, JSON.stringify(Array.from(hidden)));
+  } catch {
+    // Persisting the column setup is best-effort.
+  }
+}
+
+const viewModeStorageKey = 'project-space:issue-view-mode';
+
+export function loadIssueViewMode(): IssueViewMode {
+  try {
+    return window.localStorage.getItem(viewModeStorageKey) === 'list' ? 'list' : 'board';
+  } catch {
+    return 'board';
+  }
+}
+
+export function saveIssueViewMode(viewMode: IssueViewMode) {
+  try {
+    window.localStorage.setItem(viewModeStorageKey, viewMode);
+  } catch {
+    // Persisting the view choice is best-effort.
+  }
+}
+
+function stringHue(seed: string) {
+  let hash = 0;
+
+  for (const char of seed) {
+    hash = (hash * 31 + (char.codePointAt(0) ?? 0)) % 360_000;
+  }
+
+  return hash % 360;
+}
+
+export function labelChipStyle(label: string) {
+  const hue = stringHue(label.toLowerCase());
+
+  return {
+    backgroundColor: `hsl(${hue} 70% 60% / 0.12)`,
+    borderColor: `hsl(${hue} 70% 62% / 0.32)`,
+    color: `hsl(${hue} 82% 76%)`
+  };
+}
+
+export function authorAvatarStyle(author: string) {
+  const hue = stringHue(author.toLowerCase());
+
+  return {
+    backgroundColor: `hsl(${hue} 55% 55% / 0.22)`,
+    color: `hsl(${hue} 75% 76%)`
+  };
+}
+
+export function issueUpdatedAtLabel(issue: GitHubIssueRecord) {
+  const timestamp = issue.updatedAt ? Date.parse(issue.updatedAt) : NaN;
+
+  return Number.isFinite(timestamp) ? formatRelativeTime(timestamp) : '';
+}
+
+export function filterIssues(
+  issues: GitHubIssueRecord[],
+  query: string,
+  activeLabels: ReadonlySet<string>
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return issues.filter((issue) => {
+    if (activeLabels.size > 0 && !issue.labels.some((label) => activeLabels.has(label))) {
+      return false;
+    }
+
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    const haystack = [
+      `#${issue.number}`,
+      String(issue.number),
+      issue.title,
+      issue.author ?? '',
+      ...issue.labels
+    ]
+      .join(' ')
+      .toLowerCase();
+
+    return haystack.includes(normalizedQuery);
+  });
+}
+
+export function topIssueLabels(issues: GitHubIssueRecord[], limit = 8) {
+  const counts = new Map<string, number>();
+
+  for (const issue of issues) {
+    for (const label of issue.labels) {
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([label]) => label);
+}

--- a/src/features/project-desktop/components/issue-kanban-board.tsx
+++ b/src/features/project-desktop/components/issue-kanban-board.tsx
@@ -1,0 +1,421 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent
+} from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowRightLeft } from 'lucide-react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+  Text
+} from '@/app/dotnaos-ui';
+import { cn } from '@/lib/utils';
+import type { GitHubIssueRecord } from '@/shared/project-space-api';
+import {
+  groupIssuesByColumn,
+  type IssueColumnDefinition,
+  type IssueColumnId,
+  type IssueColumnOverrides
+} from './issue-board-model';
+import { IssueAuthorLine, IssueLabelChip } from './issue-visuals';
+
+const dragActivationDistance = 5;
+
+interface BoardDragState {
+  active: boolean;
+  fromColumn: IssueColumnId;
+  issue: GitHubIssueRecord;
+  offsetX: number;
+  offsetY: number;
+  originX: number;
+  originY: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+export function IssueKanbanBoard({
+  issues,
+  onMoveIssue,
+  onOpenIssue,
+  overrides,
+  visibleColumns
+}: {
+  issues: GitHubIssueRecord[];
+  onMoveIssue(issueNumber: number, columnId: IssueColumnId): void;
+  onOpenIssue(issueNumber: number): void;
+  overrides: IssueColumnOverrides;
+  visibleColumns: IssueColumnDefinition[];
+}) {
+  const [drag, setDrag] = useState<BoardDragState | null>(null);
+  const [dropTarget, setDropTarget] = useState<IssueColumnId | null>(null);
+  const dragRef = useRef<BoardDragState | null>(null);
+  const suppressClickRef = useRef(false);
+  const columnRefs = useRef(new Map<IssueColumnId, HTMLElement>());
+
+  const groups = groupIssuesByColumn(issues, overrides);
+
+  const updateDrag = (next: BoardDragState | null) => {
+    dragRef.current = next;
+    setDrag(next);
+  };
+
+  const moveIssueRef = useRef(onMoveIssue);
+
+  moveIssueRef.current = onMoveIssue;
+
+  const beginDrag = (
+    event: ReactPointerEvent<HTMLElement>,
+    issue: GitHubIssueRecord,
+    fromColumn: IssueColumnId
+  ) => {
+    if (event.button !== 0 || (event.target as HTMLElement).closest('[data-no-drag]')) {
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+
+    updateDrag({
+      active: false,
+      fromColumn,
+      issue,
+      offsetX: event.clientX - rect.left,
+      offsetY: event.clientY - rect.top,
+      originX: event.clientX,
+      originY: event.clientY,
+      width: rect.width,
+      x: event.clientX,
+      y: event.clientY
+    });
+  };
+
+  const isDragPending = drag !== null;
+
+  useEffect(() => {
+    if (!isDragPending) {
+      return;
+    }
+
+    const hitTestColumn = (x: number, y: number): IssueColumnId | null => {
+      for (const [columnId, element] of columnRefs.current) {
+        const rect = element.getBoundingClientRect();
+
+        if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+          return columnId;
+        }
+      }
+
+      return null;
+    };
+
+    const handleMove = (event: PointerEvent) => {
+      const current = dragRef.current;
+
+      if (!current) {
+        return;
+      }
+
+      const active =
+        current.active ||
+        Math.hypot(event.clientX - current.originX, event.clientY - current.originY) >
+          dragActivationDistance;
+
+      updateDrag({ ...current, active, x: event.clientX, y: event.clientY });
+      setDropTarget(active ? hitTestColumn(event.clientX, event.clientY) : null);
+    };
+
+    const endDrag = (commit: boolean, x?: number, y?: number) => {
+      const current = dragRef.current;
+
+      if (!current) {
+        return;
+      }
+
+      if (current.active) {
+        // The click that follows pointerup on the dragged card must not open the issue.
+        suppressClickRef.current = true;
+        window.setTimeout(() => {
+          suppressClickRef.current = false;
+        }, 0);
+
+        if (commit && x !== undefined && y !== undefined) {
+          const target = hitTestColumn(x, y);
+
+          if (target && target !== current.fromColumn) {
+            moveIssueRef.current(current.issue.number, target);
+          }
+        }
+      }
+
+      updateDrag(null);
+      setDropTarget(null);
+    };
+
+    const handleUp = (event: PointerEvent) => endDrag(true, event.clientX, event.clientY);
+    const handleCancel = () => endDrag(false);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        endDrag(false);
+      }
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleCancel);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isDragPending]);
+
+  const isDragActive = drag?.active ?? false;
+
+  useEffect(() => {
+    if (!isDragActive) {
+      return;
+    }
+
+    document.body.classList.add('issue-dragging');
+
+    return () => {
+      document.body.classList.remove('issue-dragging');
+    };
+  }, [isDragActive]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-hidden pb-2">
+      {visibleColumns.map((column) => (
+        <BoardColumn
+          key={column.id}
+          column={column}
+          moveTargets={visibleColumns.filter((target) => target.id !== column.id)}
+          columnRef={(element) => {
+            if (element) {
+              columnRefs.current.set(column.id, element);
+            } else {
+              columnRefs.current.delete(column.id);
+            }
+          }}
+          draggedIssueNumber={isDragActive ? (drag?.issue.number ?? null) : null}
+          isDragActive={isDragActive}
+          isDropTarget={isDragActive && dropTarget === column.id}
+          issues={groups[column.id]}
+          onCardPointerDown={beginDrag}
+          onMoveIssue={onMoveIssue}
+          onOpenIssue={onOpenIssue}
+          suppressClickRef={suppressClickRef}
+        />
+      ))}
+      {drag?.active
+        ? createPortal(
+            <div
+              className="pointer-events-none fixed left-0 top-0 z-[100]"
+              style={{
+                transform: `translate(${drag.x - drag.offsetX}px, ${drag.y - drag.offsetY}px)`,
+                width: drag.width
+              }}
+            >
+              <div className="issue-drag-preview rounded-lg border border-neutral-600/80 bg-neutral-900 shadow-2xl shadow-black/60 ring-1 ring-white/10">
+                <BoardCardContent issue={drag.issue} className="p-3" />
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
+  );
+}
+
+function BoardColumn({
+  column,
+  columnRef,
+  draggedIssueNumber,
+  isDragActive,
+  isDropTarget,
+  issues,
+  moveTargets,
+  onCardPointerDown,
+  onMoveIssue,
+  onOpenIssue,
+  suppressClickRef
+}: {
+  column: IssueColumnDefinition;
+  columnRef(element: HTMLElement | null): void;
+  draggedIssueNumber: number | null;
+  isDragActive: boolean;
+  isDropTarget: boolean;
+  issues: GitHubIssueRecord[];
+  moveTargets: IssueColumnDefinition[];
+  onCardPointerDown(
+    event: ReactPointerEvent<HTMLElement>,
+    issue: GitHubIssueRecord,
+    fromColumn: IssueColumnId
+  ): void;
+  onMoveIssue(issueNumber: number, columnId: IssueColumnId): void;
+  onOpenIssue(issueNumber: number): void;
+  suppressClickRef: { current: boolean };
+}) {
+  return (
+    <section
+      ref={columnRef}
+      aria-label={`${column.label} column`}
+      className={cn(
+        'flex h-full min-h-0 w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40 transition-colors',
+        isDropTarget && column.dropClass
+      )}
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-neutral-800/60 px-3 py-2.5">
+        <span className={cn('size-1.5 rounded-full', column.dotClass)} />
+        <Text className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-300">
+          {column.label}
+        </Text>
+        <Text className="ml-auto font-mono text-[11px] tabular-nums text-neutral-500">
+          {issues.length}
+        </Text>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
+        {issues.map((issue, index) => (
+          <BoardCard
+            key={issue.number}
+            column={column}
+            isDragSource={draggedIssueNumber === issue.number}
+            issue={issue}
+            moveTargets={moveTargets}
+            onMoveIssue={onMoveIssue}
+            onOpenIssue={onOpenIssue}
+            onPointerDown={onCardPointerDown}
+            style={{ animationDelay: `${Math.min(index, 8) * 35}ms` }}
+            suppressClickRef={suppressClickRef}
+          />
+        ))}
+        {issues.length === 0 ? (
+          <div
+            className={cn(
+              'flex min-h-24 flex-1 items-center justify-center rounded-lg border border-dashed border-neutral-800/80 px-3 text-center text-xs transition-colors',
+              isDragActive ? 'text-neutral-300' : 'text-neutral-600'
+            )}
+          >
+            {isDragActive ? 'Drop here' : column.hint}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function BoardCard({
+  column,
+  isDragSource,
+  issue,
+  moveTargets,
+  onMoveIssue,
+  onOpenIssue,
+  onPointerDown,
+  style,
+  suppressClickRef
+}: {
+  column: IssueColumnDefinition;
+  isDragSource: boolean;
+  issue: GitHubIssueRecord;
+  moveTargets: IssueColumnDefinition[];
+  onMoveIssue(issueNumber: number, columnId: IssueColumnId): void;
+  onOpenIssue(issueNumber: number): void;
+  onPointerDown(
+    event: ReactPointerEvent<HTMLElement>,
+    issue: GitHubIssueRecord,
+    fromColumn: IssueColumnId
+  ): void;
+  style?: React.CSSProperties;
+  suppressClickRef: { current: boolean };
+}) {
+  return (
+    <article
+      onPointerDown={(event) => onPointerDown(event, issue, column.id)}
+      onClickCapture={(event) => {
+        if (suppressClickRef.current) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      }}
+      style={style}
+      className={cn(
+        'issue-rise-in group relative shrink-0 cursor-grab touch-none select-none rounded-lg border border-neutral-800/80 bg-neutral-900/50 transition hover:-translate-y-px hover:border-neutral-700 hover:bg-neutral-900 hover:shadow-lg hover:shadow-black/30',
+        isDragSource && 'opacity-30 saturate-50'
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => onOpenIssue(issue.number)}
+        className="block w-full min-w-0 cursor-[inherit] p-3 text-left"
+      >
+        <BoardCardContent issue={issue} />
+      </button>
+      {moveTargets.length > 0 ? (
+        <div
+          data-no-drag
+          className="absolute right-1.5 top-1.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
+        >
+          <Dropdown>
+            <DropdownTrigger
+              aria-label={`Move issue #${issue.number} to another column`}
+              className="size-6 rounded-md border-transparent bg-neutral-900/80 text-neutral-500 hover:bg-neutral-800 hover:text-neutral-200"
+            >
+              <ArrowRightLeft className="size-3" />
+            </DropdownTrigger>
+            <DropdownPopover className="w-40">
+              <DropdownMenu aria-label="Move issue to column">
+                {moveTargets.map((target) => (
+                  <DropdownItem
+                    key={target.id}
+                    onPress={() => onMoveIssue(issue.number, target.id)}
+                    className="flex items-center gap-2 text-xs"
+                  >
+                    <span className={cn('size-1.5 rounded-full', target.dotClass)} />
+                    {target.label}
+                  </DropdownItem>
+                ))}
+              </DropdownMenu>
+            </DropdownPopover>
+          </Dropdown>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function BoardCardContent({
+  className,
+  issue
+}: {
+  className?: string;
+  issue: GitHubIssueRecord;
+}) {
+  return (
+    <div className={cn('min-w-0', className)}>
+      <div className="flex h-5 min-w-0 items-center gap-1.5 overflow-hidden">
+        <Text className="shrink-0 font-mono text-[11px] text-neutral-500">#{issue.number}</Text>
+        {issue.labels.slice(0, 2).map((label) => (
+          <IssueLabelChip key={label} label={label} />
+        ))}
+        {issue.labels.length > 2 ? (
+          <Text className="shrink-0 text-[10px] text-neutral-600">
+            +{issue.labels.length - 2}
+          </Text>
+        ) : null}
+      </div>
+      <Text className="mt-1.5 line-clamp-2 min-h-[2lh] text-sm font-medium leading-snug text-neutral-100">
+        {issue.title}
+      </Text>
+      <IssueAuthorLine issue={issue} className="mt-2.5 h-4" />
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/issue-list-view.tsx
+++ b/src/features/project-desktop/components/issue-list-view.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { Text } from '@/app/dotnaos-ui';
+import { cn } from '@/lib/utils';
+import type { GitHubIssueRecord } from '@/shared/project-space-api';
+import { GitHubMark } from './github-mark';
+import {
+  issueUpdatedAtLabel,
+  loadIssueColumnOverrides,
+  resolveIssueColumn,
+  type IssueColumnOverrides
+} from './issue-board-model';
+import { IssueAuthorAvatar, IssueLabelChip, IssueStatusDot } from './issue-visuals';
+
+export function IssueListView({
+  issues,
+  onOpenIssue,
+  repoFullName
+}: {
+  issues: GitHubIssueRecord[];
+  onOpenIssue(issueNumber: number): void;
+  repoFullName?: string;
+}) {
+  const [overrides, setOverrides] = useState<IssueColumnOverrides>(() =>
+    loadIssueColumnOverrides(repoFullName)
+  );
+
+  useEffect(() => {
+    setOverrides(loadIssueColumnOverrides(repoFullName));
+  }, [repoFullName]);
+
+  return (
+    <div className="issue-rise-in flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {issues.map((issue, index) => (
+          <IssueListRow
+            key={issue.number}
+            columnId={resolveIssueColumn(issue, index, overrides)}
+            isLast={index === issues.length - 1}
+            issue={issue}
+            onOpenIssue={onOpenIssue}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IssueListRow({
+  columnId,
+  isLast,
+  issue,
+  onOpenIssue
+}: {
+  columnId: ReturnType<typeof resolveIssueColumn>;
+  isLast: boolean;
+  issue: GitHubIssueRecord;
+  onOpenIssue(issueNumber: number): void;
+}) {
+  const updated = issueUpdatedAtLabel(issue);
+
+  return (
+    <div
+      className={cn(
+        'group/row flex min-w-0 items-center gap-3 pl-3 pr-2 transition hover:bg-neutral-900/50',
+        !isLast && 'border-b border-neutral-900'
+      )}
+    >
+      <IssueStatusDot columnId={columnId} />
+      <button
+        type="button"
+        onClick={() => onOpenIssue(issue.number)}
+        className="flex min-w-0 flex-1 items-center gap-3 py-2.5 text-left"
+      >
+        <Text className="w-12 shrink-0 font-mono text-xs tabular-nums text-neutral-500">
+          #{issue.number}
+        </Text>
+        <Text className="min-w-0 truncate text-sm font-medium text-neutral-100">
+          {issue.title}
+        </Text>
+        {issue.labels.length > 0 ? (
+          <span className="hidden shrink-0 items-center gap-1 md:flex">
+            {issue.labels.slice(0, 3).map((label) => (
+              <IssueLabelChip key={label} label={label} />
+            ))}
+            {issue.labels.length > 3 ? (
+              <Text className="text-[10px] text-neutral-600">+{issue.labels.length - 3}</Text>
+            ) : null}
+          </span>
+        ) : null}
+      </button>
+      <span className="hidden shrink-0 items-center gap-1.5 lg:flex">
+        {issue.author ? (
+          <>
+            <IssueAuthorAvatar author={issue.author} />
+            <Text className="max-w-28 truncate text-[11px] text-neutral-500">{issue.author}</Text>
+          </>
+        ) : null}
+      </span>
+      {updated ? (
+        <Text className="w-8 shrink-0 text-right font-mono text-[10px] tabular-nums text-neutral-600">
+          {updated}
+        </Text>
+      ) : null}
+      {issue.url ? (
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={`Open issue #${issue.number} on GitHub`}
+          title="Open on GitHub"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-neutral-600 opacity-0 transition hover:bg-neutral-800 hover:text-neutral-100 focus-visible:opacity-100 group-hover/row:opacity-100"
+        >
+          <GitHubMark className="size-3.5" />
+        </a>
+      ) : (
+        <span className="size-7 shrink-0" />
+      )}
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/issue-visuals.tsx
+++ b/src/features/project-desktop/components/issue-visuals.tsx
@@ -1,0 +1,88 @@
+import { Text } from '@/app/dotnaos-ui';
+import { cn } from '@/lib/utils';
+import type { GitHubIssueRecord } from '@/shared/project-space-api';
+import {
+  authorAvatarStyle,
+  issueColumnById,
+  issueUpdatedAtLabel,
+  labelChipStyle,
+  type IssueColumnId
+} from './issue-board-model';
+
+export function IssueLabelChip({ className, label }: { className?: string; label: string }) {
+  return (
+    <span
+      style={labelChipStyle(label)}
+      className={cn(
+        'inline-flex max-w-36 items-center truncate rounded-full border px-1.5 py-px text-[10px] font-medium leading-4',
+        className
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function IssueStatusDot({
+  className,
+  columnId
+}: {
+  className?: string;
+  columnId: IssueColumnId;
+}) {
+  const column = issueColumnById(columnId);
+
+  return (
+    <span
+      title={column.label}
+      className={cn('inline-block size-1.5 shrink-0 rounded-full', column.dotClass, className)}
+    />
+  );
+}
+
+export function IssueAuthorAvatar({
+  author,
+  className
+}: {
+  author: string;
+  className?: string;
+}) {
+  return (
+    <span
+      style={authorAvatarStyle(author)}
+      aria-hidden
+      className={cn(
+        'flex size-4 shrink-0 items-center justify-center rounded-full text-[9px] font-semibold uppercase',
+        className
+      )}
+    >
+      {author.slice(0, 1)}
+    </span>
+  );
+}
+
+export function IssueAuthorLine({
+  className,
+  issue
+}: {
+  className?: string;
+  issue: GitHubIssueRecord;
+}) {
+  const updated = issueUpdatedAtLabel(issue);
+
+  return (
+    <div className={cn('flex min-w-0 items-center gap-1.5', className)}>
+      {issue.author ? (
+        <>
+          <IssueAuthorAvatar author={issue.author} />
+          <Text className="truncate text-[11px] text-neutral-500">{issue.author}</Text>
+        </>
+      ) : (
+        <Text className="text-[11px] text-neutral-600">no author</Text>
+      )}
+      {updated ? (
+        <Text className="ml-auto shrink-0 font-mono text-[10px] text-neutral-600">{updated}</Text>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/project-desktop/components/project-detail.tsx
+++ b/src/features/project-desktop/components/project-detail.tsx
@@ -520,7 +520,7 @@ export function ProjectDetail({
 
   const targetLabel =
     selectedExplorerTarget.kind === 'worktree' ? 'Worktree path' : 'Workspace path';
-  const containsOwnScroll = tab === 'history' || (tab === 'issues' && selectedIssueNumber);
+  const containsOwnScroll = tab === 'history' || tab === 'issues';
 
   return (
     <div

--- a/src/features/project-desktop/components/project-issue-detail-panel.tsx
+++ b/src/features/project-desktop/components/project-issue-detail-panel.tsx
@@ -1,49 +1,85 @@
 import { useEffect, useState } from 'react';
 import {
   ArrowLeft,
+  Check,
   Columns3,
   ExternalLink,
   GitBranchPlus,
+  Inbox,
   List,
   ListChecks,
   Play,
-  Rocket
+  Rocket,
+  SlidersHorizontal,
+  Tags,
+  X
 } from 'lucide-react';
 import { projectSpaceClient } from '@/api/project-space-client';
-import { Button, Chip, Surface, Text, ToggleButton, ToggleButtonGroup } from '@/app/dotnaos-ui';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+  SearchField,
+  SearchFieldClearButton,
+  SearchFieldGroup,
+  SearchFieldInput,
+  SearchFieldSearchIcon,
+  Surface,
+  Text,
+  ToggleButton,
+  ToggleButtonGroup
+} from '@/app/dotnaos-ui';
+import { cn } from '@/lib/utils';
 import type {
   GitHubCatalogRepository,
   GitHubIssueRecord,
   GitHubRepositoryDetailsResult
 } from '@/shared/project-space-api';
 import { GitHubMark } from './github-mark';
+import {
+  filterIssues,
+  groupIssuesByColumn,
+  issueColumns,
+  issueUpdatedAtLabel,
+  labelChipStyle,
+  loadHiddenIssueColumns,
+  loadIssueColumnOverrides,
+  loadIssueViewMode,
+  resolveIssueColumn,
+  saveHiddenIssueColumns,
+  saveIssueColumnOverrides,
+  saveIssueViewMode,
+  topIssueLabels,
+  type IssueColumnId,
+  type IssueColumnOverrides,
+  type IssueViewMode
+} from './issue-board-model';
+import { IssueKanbanBoard } from './issue-kanban-board';
+import { IssueListView } from './issue-list-view';
+import { IssueAuthorAvatar, IssueLabelChip, IssueStatusDot } from './issue-visuals';
 import { IssueMarkdown } from './issue-markdown';
 import { repositoryDetailsFallback } from './project-main-model';
 
-export function ProjectIssueDetailPanel({
-  issueNumber,
-  onBack,
-  onOpenIssue,
-  repository
-}: {
-  issueNumber?: number;
-  onBack(): void;
-  onOpenIssue(issueNumber: number): void;
-  repository?: GitHubCatalogRepository;
-}) {
+function useRepositoryDetails(repository?: GitHubCatalogRepository) {
   const [details, setDetails] = useState<GitHubRepositoryDetailsResult>();
   const [error, setError] = useState('');
-  const [viewMode, setViewMode] = useState<'list' | 'kanban'>('list');
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!repository) {
       setDetails(undefined);
+      setError('');
+      setIsLoading(false);
       return;
     }
 
     let canceled = false;
-    setError('');
 
+    setError('');
+    setIsLoading(true);
     projectSpaceClient
       .getGitHubRepositoryDetails(repository.fullName)
       .then((nextDetails) => {
@@ -59,6 +95,11 @@ export function ProjectIssueDetailPanel({
               : 'Could not load repository details.'
           );
         }
+      })
+      .finally(() => {
+        if (!canceled) {
+          setIsLoading(false);
+        }
       });
 
     return () => {
@@ -66,274 +107,403 @@ export function ProjectIssueDetailPanel({
     };
   }, [repository]);
 
+  return { details, error, isLoading };
+}
+
+export function ProjectIssueDetailPanel({
+  issueNumber,
+  onBack,
+  onOpenIssue,
+  repository
+}: {
+  issueNumber?: number;
+  onBack(): void;
+  onOpenIssue(issueNumber: number): void;
+  repository?: GitHubCatalogRepository;
+}) {
+  const { details, error, isLoading } = useRepositoryDetails(repository);
+  const [viewMode, setViewMode] = useState<IssueViewMode>(() => loadIssueViewMode());
+  const [query, setQuery] = useState('');
+  const [activeLabels, setActiveLabels] = useState<ReadonlySet<string>>(() => new Set());
+
   const safeDetails = details ?? repositoryDetailsFallback(repository ? 'connected' : 'error');
-  const issue = safeDetails.issues.find((entry) => entry.number === issueNumber);
-  const message =
+  const issues = safeDetails.issues;
+  const issue = issues.find((entry) => entry.number === issueNumber);
+  const emptyMessage =
     error ||
     safeDetails.message ||
-    (!repository ? 'No GitHub repository is linked to this project.' : 'Loading issues...');
+    (!repository ? 'No GitHub repository is linked to this project.' : 'No open issues.');
 
   return (
     <Surface
       variant="transparent"
       className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden"
     >
-      <div className="mb-4 flex min-w-0 shrink-0 items-center justify-between gap-3">
-        {issueNumber ? (
+      {issueNumber ? (
+        <div className="mb-4 flex min-w-0 shrink-0 items-center justify-between gap-3">
           <Button size="sm" variant="ghost" onPress={onBack}>
             <ArrowLeft className="size-4" />
             Issues
           </Button>
-        ) : (
-          <div className="flex items-center gap-2">
-            <ListChecks className="size-4 text-neutral-400" />
-            <Text className="text-sm font-semibold text-neutral-100">Issues</Text>
-          </div>
-        )}
-        {issue?.url ? (
-          <a
-            href={issue.url}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-neutral-500 transition hover:bg-neutral-900 hover:text-neutral-200"
+          {issue?.url ? (
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-neutral-500 transition hover:bg-neutral-900 hover:text-neutral-200"
+            >
+              <GitHubMark className="size-3.5" />
+              Open on GitHub
+              <ExternalLink className="size-3" />
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+
+      {issue ? (
+        <IssueDetailWorkbench
+          issue={issue}
+          issues={issues}
+          onOpenIssue={onOpenIssue}
+          repoFullName={repository?.fullName}
+        />
+      ) : issueNumber ? (
+        <IssueEmptyState
+          message={details ? 'Issue was not found in the loaded open issues.' : emptyMessage}
+        />
+      ) : (
+        <IssueIndex
+          activeLabels={activeLabels}
+          emptyMessage={emptyMessage}
+          isLoading={isLoading}
+          issues={issues}
+          onActiveLabelsChange={setActiveLabels}
+          onOpenIssue={onOpenIssue}
+          onQueryChange={setQuery}
+          onViewModeChange={(nextMode) => {
+            setViewMode(nextMode);
+            saveIssueViewMode(nextMode);
+          }}
+          query={query}
+          repository={repository}
+          viewMode={viewMode}
+        />
+      )}
+    </Surface>
+  );
+}
+
+function IssueIndex({
+  activeLabels,
+  emptyMessage,
+  isLoading,
+  issues,
+  onActiveLabelsChange,
+  onOpenIssue,
+  onQueryChange,
+  onViewModeChange,
+  query,
+  repository,
+  viewMode
+}: {
+  activeLabels: ReadonlySet<string>;
+  emptyMessage: string;
+  isLoading: boolean;
+  issues: GitHubIssueRecord[];
+  onActiveLabelsChange(labels: ReadonlySet<string>): void;
+  onOpenIssue(issueNumber: number): void;
+  onQueryChange(query: string): void;
+  onViewModeChange(viewMode: IssueViewMode): void;
+  query: string;
+  repository?: GitHubCatalogRepository;
+  viewMode: IssueViewMode;
+}) {
+  const repoFullName = repository?.fullName;
+  const [overrides, setOverrides] = useState<IssueColumnOverrides>(() =>
+    loadIssueColumnOverrides(repoFullName)
+  );
+  const [hiddenColumns, setHiddenColumns] = useState<ReadonlySet<IssueColumnId>>(() =>
+    loadHiddenIssueColumns()
+  );
+
+  useEffect(() => {
+    setOverrides(loadIssueColumnOverrides(repoFullName));
+  }, [repoFullName]);
+
+  const filteredIssues = filterIssues(issues, query, activeLabels);
+  const labels = topIssueLabels(issues);
+  const hasFilter = query.trim().length > 0 || activeLabels.size > 0;
+  const visibleColumns = issueColumns.filter((column) => !hiddenColumns.has(column.id));
+  const columnGroups = groupIssuesByColumn(filteredIssues, overrides);
+
+  const moveIssue = (issueNumber: number, columnId: IssueColumnId) => {
+    setOverrides((previous) => {
+      const next = { ...previous, [issueNumber]: columnId };
+
+      saveIssueColumnOverrides(repoFullName, next);
+      return next;
+    });
+  };
+
+  const toggleColumn = (columnId: IssueColumnId) => {
+    setHiddenColumns((previous) => {
+      const next = new Set(previous);
+
+      if (next.has(columnId)) {
+        next.delete(columnId);
+      } else {
+        next.add(columnId);
+      }
+
+      saveHiddenIssueColumns(next);
+      return next;
+    });
+  };
+
+  const toggleLabel = (label: string) => {
+    const next = new Set(activeLabels);
+
+    if (next.has(label)) {
+      next.delete(label);
+    } else {
+      next.add(label);
+    }
+
+    onActiveLabelsChange(next);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-3 flex min-w-0 shrink-0 flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2">
+          <ListChecks className="size-4 text-neutral-400" />
+          <Text className="text-sm font-semibold text-neutral-100">Issues</Text>
+          <Text className="rounded-full border border-neutral-800 bg-neutral-900/70 px-2 py-0.5 font-mono text-[11px] tabular-nums text-neutral-400">
+            {hasFilter ? `${filteredIssues.length}/${issues.length}` : issues.length}
+          </Text>
+        </div>
+        <div className="ml-auto flex min-w-0 items-center gap-2">
+          <SearchField
+            aria-label="Search issues"
+            value={query}
+            onChange={onQueryChange}
+            className="w-64 max-w-full rounded-lg border border-neutral-800 bg-neutral-900/50 transition focus-within:border-neutral-600"
           >
-            Open on GitHub
-            <ExternalLink className="size-3.5" />
-          </a>
-        ) : !issueNumber ? (
+            <SearchFieldGroup className="px-2.5 py-1">
+              <SearchFieldSearchIcon />
+              <SearchFieldInput placeholder="Search title, label, #number" className="text-sm" />
+              <SearchFieldClearButton />
+            </SearchFieldGroup>
+          </SearchField>
           <ToggleButtonGroup
             aria-label="Issue view"
             selectedKeys={new Set([viewMode])}
             onSelectionChange={(keys) => {
               const nextMode = Array.from(keys)[0];
 
-              if (nextMode === 'list' || nextMode === 'kanban') {
-                setViewMode(nextMode);
+              if (nextMode === 'list' || nextMode === 'board') {
+                onViewModeChange(nextMode);
               }
             }}
-            className="rounded-lg bg-neutral-900/70 p-1"
+            className="shrink-0 rounded-lg bg-neutral-900/70 p-1"
           >
             <ToggleButton id="list" className="h-7 gap-1.5 rounded-md px-2 text-xs">
               <List className="size-3.5" />
               List
             </ToggleButton>
-            <ToggleButton id="kanban" className="h-7 gap-1.5 rounded-md px-2 text-xs">
+            <ToggleButton id="board" className="h-7 gap-1.5 rounded-md px-2 text-xs">
               <Columns3 className="size-3.5" />
-              Kanban
+              Board
             </ToggleButton>
           </ToggleButtonGroup>
-        ) : null}
+          {viewMode === 'board' ? (
+            <Dropdown>
+              <DropdownTrigger
+                aria-label="Show or hide board columns"
+                className="flex size-9 shrink-0 items-center justify-center rounded-lg border-neutral-800 bg-neutral-900/50 text-neutral-400 hover:text-neutral-200"
+              >
+                <SlidersHorizontal className="size-4" />
+              </DropdownTrigger>
+              <DropdownPopover className="w-52">
+                <DropdownMenu aria-label="Toggle board columns">
+                  <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-600">
+                    Board columns
+                  </div>
+                  {issueColumns.map((column) => {
+                    const isVisible = !hiddenColumns.has(column.id);
+                    const isLastVisible = isVisible && visibleColumns.length === 1;
+
+                    return (
+                      <DropdownItem
+                        key={column.id}
+                        isDisabled={isLastVisible}
+                        onClick={(event) => {
+                          // Keep the menu open so several columns can be toggled in a row.
+                          event.preventDefault();
+                          toggleColumn(column.id);
+                        }}
+                        className="flex items-center gap-2 text-xs"
+                      >
+                        <span
+                          className={cn(
+                            'flex size-4 shrink-0 items-center justify-center rounded border transition',
+                            isVisible
+                              ? 'border-neutral-400 bg-neutral-200 text-neutral-900'
+                              : 'border-neutral-700 text-transparent'
+                          )}
+                        >
+                          <Check className="size-3" strokeWidth={3} />
+                        </span>
+                        <span className={cn('size-1.5 shrink-0 rounded-full', column.dotClass)} />
+                        {column.label}
+                        <span className="ml-auto font-mono text-[10px] tabular-nums text-neutral-600">
+                          {columnGroups[column.id].length}
+                        </span>
+                      </DropdownItem>
+                    );
+                  })}
+                </DropdownMenu>
+              </DropdownPopover>
+            </Dropdown>
+          ) : null}
+        </div>
       </div>
 
-      {issue ? (
-        <IssueDetailWorkbench
-          issue={issue}
-          issues={safeDetails.issues}
+      {labels.length > 0 ? (
+        <div className="mb-3 flex shrink-0 flex-wrap items-center gap-1.5">
+          <Tags className="size-3.5 text-neutral-600" />
+          {labels.map((label) => {
+            const active = activeLabels.has(label);
+
+            return (
+              <button
+                key={label}
+                type="button"
+                aria-pressed={active}
+                onClick={() => toggleLabel(label)}
+                style={active ? labelChipStyle(label) : undefined}
+                className={cn(
+                  'rounded-full border px-2 py-0.5 text-[11px] font-medium transition',
+                  !active &&
+                    'border-neutral-800 text-neutral-500 hover:border-neutral-700 hover:text-neutral-300'
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+          {activeLabels.size > 0 ? (
+            <button
+              type="button"
+              onClick={() => onActiveLabelsChange(new Set())}
+              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] text-neutral-500 transition hover:text-neutral-200"
+            >
+              <X className="size-3" />
+              Clear
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {isLoading && issues.length === 0 ? (
+        <IssueBoardSkeleton viewMode={viewMode} />
+      ) : issues.length === 0 ? (
+        <IssueEmptyState message={emptyMessage} repository={repository} />
+      ) : filteredIssues.length === 0 ? (
+        <IssueEmptyState message="No issues match the current filters." />
+      ) : viewMode === 'board' ? (
+        <IssueKanbanBoard
+          issues={filteredIssues}
+          onMoveIssue={moveIssue}
           onOpenIssue={onOpenIssue}
-        />
-      ) : !issueNumber ? (
-        <IssueWorkbench
-          issues={safeDetails.issues}
-          message={message}
-          onOpenIssue={onOpenIssue}
-          viewMode={viewMode}
+          overrides={overrides}
+          visibleColumns={visibleColumns}
         />
       ) : (
-        <Text className="text-sm text-neutral-500">
-          {details ? 'Issue was not found in the loaded open issues.' : message}
-        </Text>
+        <IssueListView
+          issues={filteredIssues}
+          onOpenIssue={onOpenIssue}
+          repoFullName={repository?.fullName}
+        />
       )}
-    </Surface>
-  );
-}
-
-type KanbanColumnId = 'ready' | 'in-progress' | 'blocked' | 'backlog';
-
-const kanbanColumns: Array<{
-  id: KanbanColumnId;
-  label: string;
-}> = [
-  { id: 'ready', label: 'Ready' },
-  { id: 'in-progress', label: 'In progress' },
-  { id: 'blocked', label: 'Blocked' },
-  { id: 'backlog', label: 'Backlog' }
-];
-
-function issueStatus(issue: GitHubIssueRecord, index: number): KanbanColumnId {
-  const text = `${issue.title} ${issue.labels.join(' ')}`.toLowerCase();
-
-  if (text.includes('blocked') || text.includes('blocker') || text.includes('waiting')) {
-    return 'blocked';
-  }
-
-  if (text.includes('in progress') || text.includes('wip') || text.includes('doing')) {
-    return 'in-progress';
-  }
-
-  if (text.includes('ready') || index < 4) {
-    return 'ready';
-  }
-
-  return 'backlog';
-}
-
-function groupIssues(issues: GitHubIssueRecord[]) {
-  const groups: Record<KanbanColumnId, GitHubIssueRecord[]> = {
-    backlog: [],
-    blocked: [],
-    'in-progress': [],
-    ready: []
-  };
-
-  issues.forEach((issue, index) => {
-    groups[issueStatus(issue, index)].push(issue);
-  });
-
-  return groups;
-}
-
-function IssueWorkbench({
-  issues,
-  message,
-  onOpenIssue,
-  viewMode
-}: {
-  issues: GitHubIssueRecord[];
-  message: string;
-  onOpenIssue(issueNumber: number): void;
-  viewMode: 'list' | 'kanban';
-}) {
-  if (issues.length === 0) {
-    return <Text className="text-sm text-neutral-500">{message || 'No open issues.'}</Text>;
-  }
-
-  return viewMode === 'kanban' ? (
-    <IssueKanbanBoard issues={issues} onOpenIssue={onOpenIssue} />
-  ) : (
-    <IssueList issues={issues} onOpenIssue={onOpenIssue} />
-  );
-}
-
-function IssueList({
-  issues,
-  onOpenIssue
-}: {
-  issues: GitHubIssueRecord[];
-  onOpenIssue(issueNumber: number): void;
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <Text className="text-sm font-semibold text-neutral-100">Priority queue</Text>
-        <Chip size="sm" variant="secondary">
-          {issues.length} open
-        </Chip>
-      </div>
-      <div className="flex max-h-[calc(100vh-20rem)] min-h-0 flex-col overflow-auto">
-        {issues.map((issue) => (
-          <IssueRow key={issue.number} issue={issue} onOpenIssue={onOpenIssue} />
-        ))}
-      </div>
     </div>
   );
 }
 
-function IssueRow({
-  issue,
-  onOpenIssue
+function IssueBoardSkeleton({ viewMode }: { viewMode: IssueViewMode }) {
+  if (viewMode === 'list') {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-px overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40 p-2">
+        {Array.from({ length: 8 }, (_, index) => (
+          <div key={index} className="flex animate-pulse items-center gap-3 px-2 py-3">
+            <span className="size-1.5 rounded-full bg-neutral-800" />
+            <span className="h-3 w-10 rounded bg-neutral-800/80" />
+            <span
+              className="h-3 rounded bg-neutral-800/60"
+              style={{ width: `${34 + ((index * 13) % 40)}%` }}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-0 flex-1 auto-rows-[minmax(0,1fr)] gap-3 lg:grid-cols-2 xl:grid-cols-4">
+      {issueColumns.map((column) => (
+        <div
+          key={column.id}
+          className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40"
+        >
+          <div className="flex items-center gap-2 border-b border-neutral-800/60 px-3 py-2.5">
+            <span className={cn('size-1.5 rounded-full opacity-60', column.dotClass)} />
+            <Text className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-600">
+              {column.label}
+            </Text>
+          </div>
+          <div className="flex flex-col gap-2 p-2">
+            {Array.from({ length: 3 }, (_, index) => (
+              <div
+                key={index}
+                className="animate-pulse rounded-lg border border-neutral-800/60 bg-neutral-900/40 p-3"
+              >
+                <span className="block h-2.5 w-12 rounded bg-neutral-800/80" />
+                <span className="mt-2.5 block h-3 w-4/5 rounded bg-neutral-800/60" />
+                <span className="mt-1.5 block h-3 w-3/5 rounded bg-neutral-800/50" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function IssueEmptyState({
+  message,
+  repository
 }: {
-  issue: GitHubIssueRecord;
-  onOpenIssue(issueNumber: number): void;
+  message: string;
+  repository?: GitHubCatalogRepository;
 }) {
   return (
-    <div className="group/issue-row flex min-w-0 items-start gap-2 rounded-lg transition hover:bg-neutral-900/60">
-      <button
-        type="button"
-        onClick={() => onOpenIssue(issue.number)}
-        className="flex min-w-0 flex-1 items-start gap-3 px-2 py-3 text-left"
-      >
-        <Text className="shrink-0 text-xs text-neutral-500">#{issue.number}</Text>
-        <span className="min-w-0 flex-1">
-          <Text className="block truncate text-sm font-medium text-neutral-100">{issue.title}</Text>
-          <Text className="mt-1 block truncate text-xs text-neutral-500">
-            {issue.author ? `Opened by ${issue.author}` : 'Open issue'}
-            {issue.updatedAt ? ` · updated ${new Date(issue.updatedAt).toLocaleDateString()}` : ''}
-          </Text>
-        </span>
-      </button>
-      {issue.labels.length > 0 ? (
-        <span className="hidden max-w-44 shrink-0 flex-wrap justify-end gap-1 py-3 sm:flex">
-          {issue.labels.slice(0, 2).map((label) => (
-            <Chip key={label} size="sm" className="rounded-full bg-neutral-900 text-neutral-300">
-              {label}
-            </Chip>
-          ))}
-        </span>
-      ) : null}
-      {issue.url ? (
+    <div className="issue-rise-in flex min-h-0 flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-neutral-800/80 p-8 text-center">
+      <span className="flex size-11 items-center justify-center rounded-full border border-neutral-800 bg-neutral-900/60">
+        <Inbox className="size-5 text-neutral-500" />
+      </span>
+      <Text className="max-w-sm text-sm text-neutral-400">{message}</Text>
+      {repository ? (
         <a
-          href={issue.url}
+          href={`${repository.url}/issues`}
           target="_blank"
           rel="noreferrer"
-          aria-label={`Open issue #${issue.number} on GitHub`}
-          title="Open on GitHub"
-          className="mr-1 mt-2 flex size-7 shrink-0 items-center justify-center rounded-md text-neutral-500 transition hover:bg-neutral-800 hover:text-neutral-100"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition hover:text-neutral-200"
         >
           <GitHubMark className="size-3.5" />
+          Open issues on GitHub
+          <ExternalLink className="size-3" />
         </a>
       ) : null}
-    </div>
-  );
-}
-
-function IssueKanbanBoard({
-  issues,
-  onOpenIssue
-}: {
-  issues: GitHubIssueRecord[];
-  onOpenIssue(issueNumber: number): void;
-}) {
-  const groups = groupIssues(issues);
-
-  return (
-    <div className="min-w-0">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <Text className="text-sm font-semibold text-neutral-100">Kanban board</Text>
-        <Text className="text-xs text-neutral-500">derived from labels and recency</Text>
-      </div>
-      <div className="grid min-h-[24rem] gap-2 lg:grid-cols-2 xl:grid-cols-4">
-        {kanbanColumns.map((column) => (
-          <section
-            key={column.id}
-            className="min-w-0 rounded-lg border border-neutral-800 bg-neutral-950/45 p-3"
-          >
-            <div className="mb-2 flex items-center justify-between gap-3">
-              <Text className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-500">
-                {column.label}
-              </Text>
-              <Text className="text-xs text-neutral-600">{groups[column.id].length}</Text>
-            </div>
-            <div className="grid gap-1.5">
-              {groups[column.id].slice(0, 4).map((issue) => (
-                <button
-                  key={issue.number}
-                  type="button"
-                  onClick={() => onOpenIssue(issue.number)}
-                  className="min-w-0 rounded-md border border-neutral-800/70 bg-black/20 px-2 py-2 text-left transition hover:border-neutral-700 hover:bg-neutral-900"
-                >
-                  <Text className="block text-xs text-neutral-500">#{issue.number}</Text>
-                  <Text className="mt-1 block truncate text-sm font-medium text-neutral-100">
-                    {issue.title}
-                  </Text>
-                </button>
-              ))}
-              {groups[column.id].length === 0 ? (
-                <Text className="px-1 py-2 text-sm text-neutral-600">No issues.</Text>
-              ) : null}
-            </div>
-          </section>
-        ))}
-      </div>
     </div>
   );
 }
@@ -341,17 +511,20 @@ function IssueKanbanBoard({
 function IssueDetailWorkbench({
   issue,
   issues,
-  onOpenIssue
+  onOpenIssue,
+  repoFullName
 }: {
   issue: GitHubIssueRecord;
   issues: GitHubIssueRecord[];
   onOpenIssue(issueNumber: number): void;
+  repoFullName?: string;
 }) {
   return (
-    <div className="grid min-h-0 flex-1 gap-4 overflow-hidden lg:grid-cols-[minmax(12rem,0.58fr)_minmax(0,1.15fr)_minmax(15rem,0.72fr)]">
+    <div className="grid min-h-0 flex-1 gap-4 overflow-hidden lg:grid-cols-[minmax(13rem,0.55fr)_minmax(0,1.2fr)_minmax(14rem,0.6fr)]">
       <IssueDetailList
         issues={issues}
         onOpenIssue={onOpenIssue}
+        repoFullName={repoFullName}
         selectedIssueNumber={issue.number}
       />
       <IssueBody issue={issue} />
@@ -363,22 +536,34 @@ function IssueDetailWorkbench({
 function IssueDetailList({
   issues,
   onOpenIssue,
+  repoFullName,
   selectedIssueNumber
 }: {
   issues: GitHubIssueRecord[];
   onOpenIssue(issueNumber: number): void;
+  repoFullName?: string;
   selectedIssueNumber: number;
 }) {
+  const [overrides, setOverrides] = useState<IssueColumnOverrides>(() =>
+    loadIssueColumnOverrides(repoFullName)
+  );
+
+  useEffect(() => {
+    setOverrides(loadIssueColumnOverrides(repoFullName));
+  }, [repoFullName]);
+
   return (
-    <aside className="flex min-h-0 min-w-0 flex-col">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <Text className="text-sm font-semibold text-neutral-100">Issues</Text>
-        <Chip size="sm" variant="secondary">
+    <aside className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40">
+      <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800/60 px-3 py-2.5">
+        <Text className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-300">
+          Open issues
+        </Text>
+        <Text className="ml-auto font-mono text-[11px] tabular-nums text-neutral-500">
           {issues.length}
-        </Chip>
+        </Text>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        {issues.map((entry) => {
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-1.5">
+        {issues.map((entry, index) => {
           const isSelected = entry.number === selectedIssueNumber;
 
           return (
@@ -387,13 +572,26 @@ function IssueDetailList({
               type="button"
               onClick={() => onOpenIssue(entry.number)}
               aria-current={isSelected ? 'true' : undefined}
-              className={[
-                'min-w-0 rounded-lg px-2 py-2 text-left transition',
-                isSelected ? 'bg-neutral-800 text-neutral-50' : 'hover:bg-neutral-900/60'
-              ].join(' ')}
+              className={cn(
+                'relative min-w-0 rounded-lg px-2.5 py-2 text-left transition',
+                isSelected ? 'bg-neutral-800/80' : 'hover:bg-neutral-900/60'
+              )}
             >
-              <Text className="block text-xs text-neutral-500">#{entry.number}</Text>
-              <Text className="mt-1 block truncate text-sm font-medium text-neutral-100">
+              {isSelected ? (
+                <span className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-neutral-100" />
+              ) : null}
+              <span className="flex items-center gap-1.5">
+                <IssueStatusDot columnId={resolveIssueColumn(entry, index, overrides)} />
+                <Text className="font-mono text-[11px] tabular-nums text-neutral-500">
+                  #{entry.number}
+                </Text>
+              </span>
+              <Text
+                className={cn(
+                  'mt-0.5 block truncate text-sm',
+                  isSelected ? 'font-medium text-neutral-50' : 'text-neutral-300'
+                )}
+              >
                 {entry.title}
               </Text>
             </button>
@@ -404,16 +602,76 @@ function IssueDetailList({
   );
 }
 
+function IssueBody({ issue }: { issue: GitHubIssueRecord }) {
+  const updated = issueUpdatedAtLabel(issue);
+
+  return (
+    <article className="issue-rise-in min-h-0 min-w-0 overflow-y-auto pr-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <Text className="font-mono text-xs tabular-nums text-neutral-500">#{issue.number}</Text>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium',
+            issue.state === 'open'
+              ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300'
+              : 'border-neutral-700 bg-neutral-800/60 text-neutral-400'
+          )}
+        >
+          <span
+            className={cn(
+              'size-1.5 rounded-full',
+              issue.state === 'open' ? 'bg-emerald-400' : 'bg-neutral-500'
+            )}
+          />
+          {issue.state}
+        </span>
+      </div>
+
+      <Text
+        as="h1"
+        className="mt-3 block text-2xl font-semibold leading-tight tracking-tight text-neutral-50"
+      >
+        {issue.title}
+      </Text>
+
+      <div className="mt-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        {issue.author ? (
+          <span className="flex items-center gap-1.5">
+            <IssueAuthorAvatar author={issue.author} className="size-5 text-[10px]" />
+            <Text className="text-xs text-neutral-400">{issue.author}</Text>
+          </span>
+        ) : null}
+        {updated ? (
+          <Text className="font-mono text-[11px] text-neutral-600">updated {updated} ago</Text>
+        ) : null}
+      </div>
+
+      {issue.labels.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {issue.labels.map((label) => (
+            <IssueLabelChip key={label} label={label} className="text-[11px]" />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-5 h-px bg-neutral-800/80" />
+
+      <IssueMarkdown markdown={issue.body} />
+    </article>
+  );
+}
+
 function IssueActionPanel({ issue }: { issue: GitHubIssueRecord }) {
   return (
-    <aside className="grid min-w-0 content-start gap-3">
-      <section className="rounded-lg border border-neutral-800 bg-black/20 p-3">
+    <aside className="grid min-w-0 content-start gap-3 overflow-y-auto">
+      <section className="rounded-xl border border-neutral-800/70 bg-neutral-950/40 p-3.5">
         <div className="mb-3 flex items-center gap-2">
           <Play className="size-4 text-neutral-400" />
           <Text className="text-sm font-semibold text-neutral-100">Development session</Text>
         </div>
         <Text className="mb-3 block text-sm text-neutral-500">
-          Start work from issue #{issue.number}.
+          Start work from issue{' '}
+          <span className="font-mono text-neutral-300">#{issue.number}</span>.
         </Text>
         <div className="grid gap-2">
           <Button variant="secondary">
@@ -431,8 +689,8 @@ function IssueActionPanel({ issue }: { issue: GitHubIssueRecord }) {
         </div>
       </section>
 
-      <section className="rounded-lg border border-neutral-800 bg-black/20 p-3">
-        <Text className="mb-2 block text-sm font-semibold text-neutral-100">Issue status</Text>
+      <section className="rounded-xl border border-neutral-800/70 bg-neutral-950/40 p-3.5">
+        <Text className="mb-2.5 block text-sm font-semibold text-neutral-100">Details</Text>
         <div className="grid gap-2 text-sm">
           <div className="flex justify-between gap-3">
             <Text className="text-neutral-500">State</Text>
@@ -444,50 +702,18 @@ function IssueActionPanel({ issue }: { issue: GitHubIssueRecord }) {
           </div>
           <div className="flex justify-between gap-3">
             <Text className="text-neutral-500">Updated</Text>
-            <Text className="truncate text-neutral-200">
+            <Text className="truncate font-mono text-xs text-neutral-300">
               {issue.updatedAt ? new Date(issue.updatedAt).toLocaleDateString() : 'unknown'}
+            </Text>
+          </div>
+          <div className="flex justify-between gap-3">
+            <Text className="text-neutral-500">Labels</Text>
+            <Text className="font-mono text-xs tabular-nums text-neutral-300">
+              {issue.labels.length}
             </Text>
           </div>
         </div>
       </section>
     </aside>
-  );
-}
-
-function IssueBody({ issue }: { issue: GitHubIssueRecord }) {
-  return (
-    <article className="min-h-0 min-w-0 overflow-auto pr-3">
-      <div className="flex min-w-0 items-center gap-2">
-        <ListChecks className="size-4 shrink-0 text-neutral-400" />
-        <Text className="shrink-0 text-xs text-neutral-500">#{issue.number}</Text>
-        <Chip size="sm" className="rounded-full px-2 py-0.5 text-emerald-300">
-          {issue.state}
-        </Chip>
-      </div>
-
-      <Text className="mt-3 block text-xl font-semibold leading-7 text-neutral-50">
-        {issue.title}
-      </Text>
-      <Text className="mt-2 block text-sm text-neutral-500">
-        {issue.author ? `Opened by ${issue.author}` : 'Open issue'}
-        {issue.updatedAt ? ` · updated ${new Date(issue.updatedAt).toLocaleDateString()}` : ''}
-      </Text>
-
-      {issue.labels.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-1.5">
-          {issue.labels.map((label) => (
-            <Chip
-              key={label}
-              size="sm"
-              className="rounded-full bg-neutral-900 px-2 py-0.5 text-neutral-300"
-            >
-              {label}
-            </Chip>
-          ))}
-        </div>
-      ) : null}
-
-      <IssueMarkdown markdown={issue.body} />
-    </article>
   );
 }

--- a/src/features/project-desktop/components/project-main-panel.tsx
+++ b/src/features/project-desktop/components/project-main-panel.tsx
@@ -297,7 +297,7 @@ export function ProjectMainPanel({
     mainView === 'project' &&
     project &&
     project.kind !== 'github' &&
-    (projectTab === 'history' || (projectTab === 'issues' && selectedIssueNumber));
+    (projectTab === 'history' || projectTab === 'issues');
 
   return (
     <Surface variant="transparent" className="flex min-h-0 flex-col rounded-none bg-app-panel">


### PR DESCRIPTION
## Summary
- redesign project issues into list/board modes
- add kanban columns with local column overrides and drag support
- keep the kanban board horizontally scrollable with fixed-width columns instead of a responsive grid
- make the Issues tab own its scroll area

## Verification
- bun run check
- bun run build
- git diff --check
- local Issues page renders without console errors