### PR TITLE
Persist GitHub login and edit issues

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@wterm/dom": "^0.3.0",
         "lucide-react": "^0.577.0",
         "node-pty": "^1.1.0",
+        "pg": "^8.22.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "ws": "^8.21.0",
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^24.3.0",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@types/ws": "^8.18.1",
@@ -399,6 +401,8 @@
 
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "19.2.14" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -605,11 +609,35 @@
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
+    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "3.3.11", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
@@ -665,6 +693,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
@@ -710,6 +740,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.0", "", {}, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -12,6 +12,7 @@ services:
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID:-}
+      DATABASE_URL: ${DATABASE_URL:-postgres://project_space:${PROJECT_SPACE_POSTGRES_PASSWORD:-project_space}@db:5432/project_space}
       PROJECT_SPACE_ALLOWED_EMAILS: ${PROJECT_SPACE_ALLOWED_EMAILS:-}
       PROJECT_SPACE_ALLOWED_GITHUB_LOGINS: ${PROJECT_SPACE_ALLOWED_GITHUB_LOGINS:-}
       PROJECT_SPACE_AUTH_DISABLED: ${PROJECT_SPACE_AUTH_DISABLED:-}
@@ -23,6 +24,9 @@ services:
     volumes:
       - ..:/workspace/backend-repo:ro
       - ../ssh:/root/.ssh:ro
+    depends_on:
+      db:
+        condition: service_healthy
 
   docs:
     build:
@@ -30,3 +34,21 @@ services:
       dockerfile: apps/docs/Dockerfile
     image: project-space-docs:local
     restart: unless-stopped
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: ${PROJECT_SPACE_POSTGRES_DB:-project_space}
+      POSTGRES_PASSWORD: ${PROJECT_SPACE_POSTGRES_PASSWORD:-project_space}
+      POSTGRES_USER: ${PROJECT_SPACE_POSTGRES_USER:-project_space}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@wterm/dom": "^0.3.0",
     "lucide-react": "^0.577.0",
     "node-pty": "^1.1.0",
+    "pg": "^8.22.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "ws": "^8.21.0",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "@types/node": "^24.3.0",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       react:
         specifier: ^19.1.1
         version: 19.2.4
@@ -45,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.12.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/react':
         specifier: ^19.1.10
         version: 19.2.14
@@ -1268,6 +1274,9 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1700,6 +1709,40 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1710,6 +1753,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -1843,6 +1902,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -2014,6 +2077,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3205,6 +3272,12 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 24.12.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3625,6 +3698,41 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -3634,6 +3742,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   progress@2.0.3: {}
 
@@ -3810,6 +3928,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -3914,6 +4034,8 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.21.0: {}
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/server/local-database-store.ts
+++ b/server/local-database-store.ts
@@ -1,0 +1,178 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+
+import pg from 'pg';
+
+interface StoredGitHubOAuthToken {
+  accessToken: string;
+  createdAt: string;
+  login?: string;
+  scope?: string;
+  tokenType?: string;
+}
+
+interface GitHubOAuthTokenRow {
+  created_at: Date;
+  encrypted_access_token: string;
+  iv: string;
+  login: string | null;
+  scope: string | null;
+  tag: string;
+  token_type: string | null;
+}
+
+let pool: pg.Pool | null = null;
+let schemaReady: Promise<void> | null = null;
+
+function databaseUrl() {
+  return process.env.DATABASE_URL ?? process.env.POSTGRES_URL ?? '';
+}
+
+export function isDatabaseConfigured() {
+  return Boolean(databaseUrl());
+}
+
+function getPool() {
+  const url = databaseUrl();
+
+  if (!url) {
+    return null;
+  }
+
+  pool ??= new pg.Pool({
+    connectionString: url,
+    max: 4
+  });
+
+  return pool;
+}
+
+function encryptionKey() {
+  const source =
+    process.env.PROJECT_SPACE_TOKEN_ENCRYPTION_KEY ??
+    process.env.CLERK_SECRET_KEY ??
+    process.env.PROJECT_CONNECTOR_REGISTRATION_TOKEN ??
+    databaseUrl();
+
+  return createHash('sha256').update(source).digest();
+}
+
+function encrypt(value: string) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+
+  return {
+    encrypted: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64')
+  };
+}
+
+function decrypt(row: Pick<GitHubOAuthTokenRow, 'encrypted_access_token' | 'iv' | 'tag'>) {
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    encryptionKey(),
+    Buffer.from(row.iv, 'base64')
+  );
+  decipher.setAuthTag(Buffer.from(row.tag, 'base64'));
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(row.encrypted_access_token, 'base64')),
+    decipher.final()
+  ]).toString('utf8');
+}
+
+async function ensureSchema() {
+  const client = getPool();
+
+  if (!client) {
+    return;
+  }
+
+  schemaReady ??= client.query(`
+    create table if not exists github_oauth_tokens (
+      user_id text primary key,
+      login text,
+      encrypted_access_token text not null,
+      iv text not null,
+      tag text not null,
+      scope text,
+      token_type text,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    )
+  `).then(() => undefined);
+
+  await schemaReady;
+}
+
+export async function readGitHubOAuthToken(
+  userId: string
+): Promise<StoredGitHubOAuthToken | null> {
+  const client = getPool();
+
+  if (!client) {
+    return null;
+  }
+
+  await ensureSchema();
+
+  const result = await client.query<GitHubOAuthTokenRow>(
+    `select login, encrypted_access_token, iv, tag, scope, token_type, created_at
+       from github_oauth_tokens
+      where user_id = $1`,
+    [userId]
+  );
+  const row = result.rows[0];
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    accessToken: decrypt(row),
+    createdAt: row.created_at.toISOString(),
+    login: row.login ?? undefined,
+    scope: row.scope ?? undefined,
+    tokenType: row.token_type ?? undefined
+  };
+}
+
+export async function writeGitHubOAuthToken(
+  userId: string,
+  token: StoredGitHubOAuthToken
+) {
+  const client = getPool();
+
+  if (!client) {
+    throw new Error('DATABASE_URL is required to persist GitHub login for this account.');
+  }
+
+  await ensureSchema();
+
+  const encrypted = encrypt(token.accessToken);
+
+  await client.query(
+    `insert into github_oauth_tokens (
+        user_id, login, encrypted_access_token, iv, tag, scope, token_type, created_at, updated_at
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, now(), now())
+      on conflict (user_id) do update set
+        login = excluded.login,
+        encrypted_access_token = excluded.encrypted_access_token,
+        iv = excluded.iv,
+        tag = excluded.tag,
+        scope = excluded.scope,
+        token_type = excluded.token_type,
+        updated_at = now()`,
+    [
+      userId,
+      token.login ?? null,
+      encrypted.encrypted,
+      encrypted.iv,
+      encrypted.tag,
+      token.scope ?? null,
+      token.tokenType ?? null
+    ]
+  );
+}

--- a/server/local-github-catalog.ts
+++ b/server/local-github-catalog.ts
@@ -7,18 +7,22 @@ import type {
   GitHubBranchRecord,
   GitHubCatalogRepository,
   GitHubCatalogResult,
+  GitHubIssueCreateRequest,
+  GitHubIssueMutationResult,
   GitHubIssueRecord,
+  GitHubIssueUpdateRequest,
   GitHubOAuthDevicePollRequest,
   GitHubOAuthDevicePollResult,
   GitHubOAuthDeviceStartResult,
   GitHubRepositoryDetailsResult,
   GitHubProjectConfigStatus
 } from '../src/shared/project-space-api';
+import { getCurrentAuthSession, isProjectSpaceAuthRequired } from './local-auth-store';
 import {
-  getCurrentAuthSession,
-  getCurrentGitHubToken,
-  isProjectSpaceAuthRequired
-} from './local-auth-store';
+  isDatabaseConfigured,
+  readGitHubOAuthToken,
+  writeGitHubOAuthToken
+} from './local-database-store';
 
 interface StoredGitHubToken {
   accessToken: string;
@@ -162,17 +166,19 @@ async function resolveToken(): Promise<TokenResolution | null> {
     return null;
   }
 
-  const sessionToken = getCurrentGitHubToken();
+  if (currentSession && isDatabaseConfigured()) {
+    const storedForUser = await readGitHubOAuthToken(currentSession.userId);
 
-  if (sessionToken) {
-    return {
-      login: currentSession?.login,
-      source: 'stored-oauth',
-      token: sessionToken
-    };
+    if (storedForUser) {
+      return {
+        login: storedForUser.login ?? currentSession.login,
+        source: 'stored-oauth',
+        token: storedForUser.accessToken
+      };
+    }
   }
 
-  const stored = readStoredToken();
+  const stored = !isProjectSpaceAuthRequired() ? readStoredToken() : null;
 
   if (stored) {
     return {
@@ -354,6 +360,19 @@ function createEmptyRepositoryDetails(
   };
 }
 
+function mapGitHubIssue(issue: GitHubApiIssue): GitHubIssueRecord {
+  return {
+    author: issue.user?.login,
+    body: issue.body ?? undefined,
+    labels: issue.labels?.map((label) => label.name).filter((name): name is string => Boolean(name)) ?? [],
+    number: issue.number,
+    state: issue.state,
+    title: issue.title,
+    updatedAt: issue.updated_at ?? undefined,
+    url: issue.html_url
+  };
+}
+
 export async function getGitHubRepositoryDetails(
   fullName: string
 ): Promise<GitHubRepositoryDetailsResult> {
@@ -391,22 +410,130 @@ export async function getGitHubRepositoryDetails(
       checkedAt: new Date().toISOString(),
       issues: issues
         .filter((issue) => !issue.pull_request)
-        .map<GitHubIssueRecord>((issue) => ({
-          author: issue.user?.login,
-          body: issue.body ?? undefined,
-          labels: issue.labels?.map((label) => label.name).filter((name): name is string => Boolean(name)) ?? [],
-          number: issue.number,
-          state: issue.state,
-          title: issue.title,
-          updatedAt: issue.updated_at ?? undefined,
-          url: issue.html_url
-        })),
+        .map(mapGitHubIssue),
       status: 'connected'
     };
   } catch (error) {
     return createEmptyRepositoryDetails(
       'error',
       error instanceof Error ? error.message : 'Could not load GitHub repository details.'
+    );
+  }
+}
+
+function createIssueMutationError(
+  status: GitHubCatalogResult['status'],
+  message?: string
+): GitHubIssueMutationResult {
+  return {
+    message,
+    status
+  };
+}
+
+export async function createGitHubIssue({
+  body,
+  fullName,
+  labels,
+  title
+}: GitHubIssueCreateRequest): Promise<GitHubIssueMutationResult> {
+  const auth = await resolveToken();
+
+  if (!auth) {
+    return createIssueMutationError(
+      getGitHubClientId() ? 'auth-required' : 'not-configured',
+      getGitHubClientId() ? 'Connect GitHub to create issues.' : githubOAuthClientIdMissingMessage
+    );
+  }
+
+  if (!title.trim()) {
+    return createIssueMutationError('error', 'Issue title is required.');
+  }
+
+  try {
+    const repoPath = fullName.split('/').map(encodeURIComponent).join('/');
+    const issue = await requestGitHub<GitHubApiIssue>(`/repos/${repoPath}/issues`, auth.token, {
+      body: JSON.stringify({
+        body: body?.trim() || undefined,
+        labels: labels?.filter(Boolean),
+        title: title.trim()
+      }),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    });
+
+    return {
+      issue: mapGitHubIssue(issue),
+      status: 'connected'
+    };
+  } catch (error) {
+    return createIssueMutationError(
+      'error',
+      error instanceof Error ? error.message : 'Could not create GitHub issue.'
+    );
+  }
+}
+
+export async function updateGitHubIssue({
+  body,
+  fullName,
+  labels,
+  number,
+  state,
+  title
+}: GitHubIssueUpdateRequest): Promise<GitHubIssueMutationResult> {
+  const auth = await resolveToken();
+
+  if (!auth) {
+    return createIssueMutationError(
+      getGitHubClientId() ? 'auth-required' : 'not-configured',
+      getGitHubClientId() ? 'Connect GitHub to edit issues.' : githubOAuthClientIdMissingMessage
+    );
+  }
+
+  try {
+    const repoPath = fullName.split('/').map(encodeURIComponent).join('/');
+    const payload: Record<string, unknown> = {};
+
+    if (title !== undefined) {
+      payload.title = title.trim();
+    }
+    if (body !== undefined) {
+      payload.body = body;
+    }
+    if (labels !== undefined) {
+      payload.labels = labels.filter(Boolean);
+    }
+    if (state !== undefined) {
+      payload.state = state;
+    }
+
+    if (typeof payload.title === 'string' && !payload.title) {
+      return createIssueMutationError('error', 'Issue title is required.');
+    }
+
+    const issue = await requestGitHub<GitHubApiIssue>(
+      `/repos/${repoPath}/issues/${number}`,
+      auth.token,
+      {
+        body: JSON.stringify(payload),
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        method: 'PATCH'
+      }
+    );
+
+    return {
+      issue: mapGitHubIssue(issue),
+      status: 'connected'
+    };
+  } catch (error) {
+    return createIssueMutationError(
+      'error',
+      error instanceof Error ? error.message : 'Could not edit GitHub issue.'
     );
   }
 }
@@ -520,14 +647,20 @@ export async function pollGitHubOAuthDeviceFlow({
   }
 
   const login = await readLogin(payload.access_token);
-
-  writeStoredToken({
+  const storedToken = {
     accessToken: payload.access_token,
     createdAt: new Date().toISOString(),
     login,
     scope: payload.scope,
     tokenType: payload.token_type
-  });
+  };
+  const currentSession = getCurrentAuthSession();
+
+  if (currentSession) {
+    await writeGitHubOAuthToken(currentSession.userId, storedToken);
+  } else {
+    writeStoredToken(storedToken);
+  }
 
   return {
     catalog: await getGitHubCatalog(),

--- a/server/local-project-space-backend.ts
+++ b/server/local-project-space-backend.ts
@@ -21,10 +21,12 @@ import {
   unstageGitPaths
 } from './local-git-client';
 import {
+  createGitHubIssue,
   getGitHubCatalog,
   getGitHubRepositoryDetails,
   pollGitHubOAuthDeviceFlow,
-  startGitHubOAuthDeviceFlow
+  startGitHubOAuthDeviceFlow,
+  updateGitHubIssue
 } from './local-github-catalog';
 import {
   loadInstalledLauncherApps,
@@ -653,8 +655,14 @@ export function createLocalProjectSpaceBackend(
     async getGitHubCatalog() {
       return getGitHubCatalog();
     },
+    async createGitHubIssue(request) {
+      return createGitHubIssue(request);
+    },
     async getGitHubRepositoryDetails(fullName: string) {
       return getGitHubRepositoryDetails(fullName);
+    },
+    async updateGitHubIssue(request) {
+      return updateGitHubIssue(request);
     },
     async getGitDiff(request) {
       return getGitDiff(request);

--- a/server/project-space-http.ts
+++ b/server/project-space-http.ts
@@ -28,6 +28,8 @@ import type {
   GitCommitRequest,
   GitDiffRequest,
   GitHistoryRequest,
+  GitHubIssueCreateRequest,
+  GitHubIssueUpdateRequest,
   GitStageRequest,
   ProjectDeployRequest,
   ProjectDirectorySelection,
@@ -58,7 +60,7 @@ const contentTypes: Record<string, string> = {
 function writeJson(response: ServerResponse, statusCode: number, payload: unknown) {
   response.writeHead(statusCode, {
     'Access-Control-Allow-Headers': 'Authorization, Content-Type',
-    'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,OPTIONS',
     'Access-Control-Allow-Private-Network': 'true',
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json; charset=utf-8'
@@ -69,7 +71,7 @@ function writeJson(response: ServerResponse, statusCode: number, payload: unknow
 function writeEmpty(response: ServerResponse, statusCode = 204) {
   response.writeHead(statusCode, {
     'Access-Control-Allow-Headers': 'Authorization, Content-Type',
-    'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,OPTIONS',
     'Access-Control-Allow-Private-Network': 'true',
     'Access-Control-Allow-Origin': '*'
   });
@@ -429,6 +431,18 @@ function createApiHandler(backend: ProjectSpaceBackend) {
         }
 
         writeJson(response, 200, await backend.getGitHubRepositoryDetails(fullName));
+        return true;
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/github/issues') {
+        const payload = await readJson<GitHubIssueCreateRequest>(request);
+        writeJson(response, 200, await backend.createGitHubIssue(payload));
+        return true;
+      }
+
+      if (request.method === 'PATCH' && url.pathname === '/api/github/issues') {
+        const payload = await readJson<GitHubIssueUpdateRequest>(request);
+        writeJson(response, 200, await backend.updateGitHubIssue(payload));
         return true;
       }
 

--- a/src/api/project-space-client.ts
+++ b/src/api/project-space-client.ts
@@ -11,6 +11,9 @@ import type {
   GitHistoryRequest,
   GitHistoryResult,
   GitHubCatalogResult,
+  GitHubIssueCreateRequest,
+  GitHubIssueMutationResult,
+  GitHubIssueUpdateRequest,
   GitHubRepositoryDetailsResult,
   GitHubOAuthDevicePollRequest,
   GitHubOAuthDevicePollResult,
@@ -179,10 +182,24 @@ class HttpProjectSpaceClient implements ProjectSpaceBackend {
     return this.request('/api/github/catalog');
   }
 
+  createGitHubIssue(request: GitHubIssueCreateRequest): Promise<GitHubIssueMutationResult> {
+    return this.request('/api/github/issues', {
+      body: JSON.stringify(request),
+      method: 'POST'
+    });
+  }
+
   getGitHubRepositoryDetails(fullName: string): Promise<GitHubRepositoryDetailsResult> {
     const query = new URLSearchParams({ fullName });
 
     return this.request(`/api/github/repository-details?${query.toString()}`);
+  }
+
+  updateGitHubIssue(request: GitHubIssueUpdateRequest): Promise<GitHubIssueMutationResult> {
+    return this.request('/api/github/issues', {
+      body: JSON.stringify(request),
+      method: 'PATCH'
+    });
   }
 
   getGitDiff(request: GitDiffRequest): Promise<GitDiffResult> {

--- a/src/features/project-desktop/components/project-issue-detail-panel.tsx
+++ b/src/features/project-desktop/components/project-issue-detail-panel.tsx
@@ -8,8 +8,11 @@ import {
   Inbox,
   List,
   ListChecks,
+  Pencil,
+  Plus,
   Play,
   Rocket,
+  Save,
   SlidersHorizontal,
   Tags,
   X
@@ -107,7 +110,7 @@ function useRepositoryDetails(repository?: GitHubCatalogRepository) {
     };
   }, [repository]);
 
-  return { details, error, isLoading };
+  return { details, error, isLoading, setDetails };
 }
 
 export function ProjectIssueDetailPanel({
@@ -121,7 +124,7 @@ export function ProjectIssueDetailPanel({
   onOpenIssue(issueNumber: number): void;
   repository?: GitHubCatalogRepository;
 }) {
-  const { details, error, isLoading } = useRepositoryDetails(repository);
+  const { details, error, isLoading, setDetails } = useRepositoryDetails(repository);
   const [viewMode, setViewMode] = useState<IssueViewMode>(() => loadIssueViewMode());
   const [query, setQuery] = useState('');
   const [activeLabels, setActiveLabels] = useState<ReadonlySet<string>>(() => new Set());
@@ -133,6 +136,22 @@ export function ProjectIssueDetailPanel({
     error ||
     safeDetails.message ||
     (!repository ? 'No GitHub repository is linked to this project.' : 'No open issues.');
+
+  const upsertIssue = (nextIssue: GitHubIssueRecord) => {
+    setDetails((previous) => {
+      const base = previous ?? safeDetails;
+      const exists = base.issues.some((entry) => entry.number === nextIssue.number);
+      const nextIssues = exists
+        ? base.issues.map((entry) => (entry.number === nextIssue.number ? nextIssue : entry))
+        : [nextIssue, ...base.issues];
+
+      return {
+        ...base,
+        checkedAt: new Date().toISOString(),
+        issues: nextIssues
+      };
+    });
+  };
 
   return (
     <Surface
@@ -165,6 +184,7 @@ export function ProjectIssueDetailPanel({
           issue={issue}
           issues={issues}
           onOpenIssue={onOpenIssue}
+          onIssueUpdated={upsertIssue}
           repoFullName={repository?.fullName}
         />
       ) : issueNumber ? (
@@ -178,6 +198,7 @@ export function ProjectIssueDetailPanel({
           isLoading={isLoading}
           issues={issues}
           onActiveLabelsChange={setActiveLabels}
+          onIssueCreated={upsertIssue}
           onOpenIssue={onOpenIssue}
           onQueryChange={setQuery}
           onViewModeChange={(nextMode) => {
@@ -199,6 +220,7 @@ function IssueIndex({
   isLoading,
   issues,
   onActiveLabelsChange,
+  onIssueCreated,
   onOpenIssue,
   onQueryChange,
   onViewModeChange,
@@ -211,6 +233,7 @@ function IssueIndex({
   isLoading: boolean;
   issues: GitHubIssueRecord[];
   onActiveLabelsChange(labels: ReadonlySet<string>): void;
+  onIssueCreated(issue: GitHubIssueRecord): void;
   onOpenIssue(issueNumber: number): void;
   onQueryChange(query: string): void;
   onViewModeChange(viewMode: IssueViewMode): void;
@@ -225,6 +248,8 @@ function IssueIndex({
   const [hiddenColumns, setHiddenColumns] = useState<ReadonlySet<IssueColumnId>>(() =>
     loadHiddenIssueColumns()
   );
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState('');
 
   useEffect(() => {
     setOverrides(loadIssueColumnOverrides(repoFullName));
@@ -272,6 +297,28 @@ function IssueIndex({
     onActiveLabelsChange(next);
   };
 
+  const createIssue = async (values: IssueFormValues) => {
+    if (!repository) {
+      return;
+    }
+
+    setCreateError('');
+    const result = await projectSpaceClient.createGitHubIssue({
+      body: values.body,
+      fullName: repository.fullName,
+      labels: values.labels,
+      title: values.title
+    });
+
+    if (result.status !== 'connected' || !result.issue) {
+      setCreateError(result.message ?? 'Could not create issue.');
+      return;
+    }
+
+    onIssueCreated(result.issue);
+    setIsCreating(false);
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="mb-3 flex min-w-0 shrink-0 flex-wrap items-center gap-2">
@@ -283,6 +330,19 @@ function IssueIndex({
           </Text>
         </div>
         <div className="ml-auto flex min-w-0 items-center gap-2">
+          {repository ? (
+            <Button
+              size="sm"
+              variant={isCreating ? 'ghost' : 'secondary'}
+              onPress={() => {
+                setCreateError('');
+                setIsCreating((value) => !value);
+              }}
+            >
+              {isCreating ? <X className="size-4" /> : <Plus className="size-4" />}
+              {isCreating ? 'Cancel' : 'New issue'}
+            </Button>
+          ) : null}
           <SearchField
             aria-label="Search issues"
             value={query}
@@ -369,6 +429,21 @@ function IssueIndex({
         </div>
       </div>
 
+      {isCreating && repository ? (
+        <IssueEditor
+          error={createError}
+          initialBody=""
+          initialLabels={[]}
+          initialTitle=""
+          onCancel={() => {
+            setCreateError('');
+            setIsCreating(false);
+          }}
+          onSubmit={createIssue}
+          submitLabel="Create issue"
+        />
+      ) : null}
+
       {labels.length > 0 ? (
         <div className="mb-3 flex shrink-0 flex-wrap items-center gap-1.5">
           <Tags className="size-3.5 text-neutral-600" />
@@ -449,11 +524,11 @@ function IssueBoardSkeleton({ viewMode }: { viewMode: IssueViewMode }) {
   }
 
   return (
-    <div className="grid min-h-0 flex-1 auto-rows-[minmax(0,1fr)] gap-3 lg:grid-cols-2 xl:grid-cols-4">
+    <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-hidden pb-2">
       {issueColumns.map((column) => (
         <div
           key={column.id}
-          className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40"
+          className="flex h-full min-h-0 w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-neutral-800/70 bg-neutral-950/40"
         >
           <div className="flex items-center gap-2 border-b border-neutral-800/60 px-3 py-2.5">
             <span className={cn('size-1.5 rounded-full opacity-60', column.dotClass)} />
@@ -511,11 +586,13 @@ function IssueEmptyState({
 function IssueDetailWorkbench({
   issue,
   issues,
+  onIssueUpdated,
   onOpenIssue,
   repoFullName
 }: {
   issue: GitHubIssueRecord;
   issues: GitHubIssueRecord[];
+  onIssueUpdated(issue: GitHubIssueRecord): void;
   onOpenIssue(issueNumber: number): void;
   repoFullName?: string;
 }) {
@@ -527,7 +604,7 @@ function IssueDetailWorkbench({
         repoFullName={repoFullName}
         selectedIssueNumber={issue.number}
       />
-      <IssueBody issue={issue} />
+      <IssueBody issue={issue} onIssueUpdated={onIssueUpdated} repoFullName={repoFullName} />
       <IssueActionPanel issue={issue} />
     </div>
   );
@@ -602,8 +679,41 @@ function IssueDetailList({
   );
 }
 
-function IssueBody({ issue }: { issue: GitHubIssueRecord }) {
+function IssueBody({
+  issue,
+  onIssueUpdated,
+  repoFullName
+}: {
+  issue: GitHubIssueRecord;
+  onIssueUpdated(issue: GitHubIssueRecord): void;
+  repoFullName?: string;
+}) {
   const updated = issueUpdatedAtLabel(issue);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editError, setEditError] = useState('');
+
+  const updateIssue = async (values: IssueFormValues) => {
+    if (!repoFullName) {
+      return;
+    }
+
+    setEditError('');
+    const result = await projectSpaceClient.updateGitHubIssue({
+      body: values.body,
+      fullName: repoFullName,
+      labels: values.labels,
+      number: issue.number,
+      title: values.title
+    });
+
+    if (result.status !== 'connected' || !result.issue) {
+      setEditError(result.message ?? 'Could not edit issue.');
+      return;
+    }
+
+    onIssueUpdated(result.issue);
+    setIsEditing(false);
+  };
 
   return (
     <article className="issue-rise-in min-h-0 min-w-0 overflow-y-auto pr-3">
@@ -644,6 +754,20 @@ function IssueBody({ issue }: { issue: GitHubIssueRecord }) {
         {updated ? (
           <Text className="font-mono text-[11px] text-neutral-600">updated {updated} ago</Text>
         ) : null}
+        {repoFullName ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="ml-auto"
+            onPress={() => {
+              setEditError('');
+              setIsEditing((value) => !value);
+            }}
+          >
+            {isEditing ? <X className="size-4" /> : <Pencil className="size-4" />}
+            {isEditing ? 'Cancel edit' : 'Edit'}
+          </Button>
+        ) : null}
       </div>
 
       {issue.labels.length > 0 ? (
@@ -656,8 +780,113 @@ function IssueBody({ issue }: { issue: GitHubIssueRecord }) {
 
       <div className="mt-5 h-px bg-neutral-800/80" />
 
-      <IssueMarkdown markdown={issue.body} />
+      {isEditing ? (
+        <IssueEditor
+          error={editError}
+          initialBody={issue.body ?? ''}
+          initialLabels={issue.labels}
+          initialTitle={issue.title}
+          onCancel={() => {
+            setEditError('');
+            setIsEditing(false);
+          }}
+          onSubmit={updateIssue}
+          submitLabel="Save issue"
+        />
+      ) : (
+        <IssueMarkdown markdown={issue.body} />
+      )}
     </article>
+  );
+}
+
+interface IssueFormValues {
+  body: string;
+  labels: string[];
+  title: string;
+}
+
+function labelsFromInput(value: string) {
+  return value
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
+function IssueEditor({
+  error,
+  initialBody,
+  initialLabels,
+  initialTitle,
+  onCancel,
+  onSubmit,
+  submitLabel
+}: {
+  error: string;
+  initialBody: string;
+  initialLabels: string[];
+  initialTitle: string;
+  onCancel(): void;
+  onSubmit(values: IssueFormValues): Promise<void>;
+  submitLabel: string;
+}) {
+  const [body, setBody] = useState(initialBody);
+  const [labels, setLabels] = useState(initialLabels.join(', '));
+  const [title, setTitle] = useState(initialTitle);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submit = async () => {
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        body,
+        labels: labelsFromInput(labels),
+        title
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="issue-rise-in mb-4 rounded-xl border border-neutral-800/70 bg-neutral-950/40 p-3">
+      <div className="grid gap-2">
+        <input
+          value={title}
+          onChange={(event) => setTitle(event.currentTarget.value)}
+          placeholder="Issue title"
+          className="h-9 rounded-lg border border-neutral-800 bg-neutral-950 px-3 text-sm text-neutral-100 outline-none transition placeholder:text-neutral-600 focus:border-neutral-600"
+        />
+        <textarea
+          value={body}
+          onChange={(event) => setBody(event.currentTarget.value)}
+          placeholder="Markdown description"
+          rows={8}
+          className="min-h-40 resize-y rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm leading-6 text-neutral-100 outline-none transition placeholder:text-neutral-600 focus:border-neutral-600"
+        />
+        <input
+          value={labels}
+          onChange={(event) => setLabels(event.currentTarget.value)}
+          placeholder="Labels, comma separated"
+          className="h-9 rounded-lg border border-neutral-800 bg-neutral-950 px-3 text-sm text-neutral-100 outline-none transition placeholder:text-neutral-600 focus:border-neutral-600"
+        />
+      </div>
+      {error ? <Text className="mt-2 block text-xs text-red-300">{error}</Text> : null}
+      <div className="mt-3 flex justify-end gap-2">
+        <Button size="sm" variant="ghost" onPress={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          isDisabled={isSubmitting || !title.trim()}
+          variant="primary"
+          onPress={() => void submit()}
+        >
+          <Save className="size-4" />
+          {isSubmitting ? 'Saving...' : submitLabel}
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -276,6 +276,28 @@ export interface GitHubIssueRecord {
   url: string;
 }
 
+export interface GitHubIssueCreateRequest {
+  body?: string;
+  fullName: string;
+  labels?: string[];
+  title: string;
+}
+
+export interface GitHubIssueUpdateRequest {
+  body?: string;
+  fullName: string;
+  labels?: string[];
+  number: number;
+  state?: 'open' | 'closed';
+  title?: string;
+}
+
+export interface GitHubIssueMutationResult {
+  issue?: GitHubIssueRecord;
+  message?: string;
+  status: GitHubCatalogStatus;
+}
+
 export interface GitHubRepositoryDetailsResult {
   branches: GitHubBranchRecord[];
   checkedAt: string;
@@ -701,7 +723,9 @@ export interface ProjectSpaceBackend {
     request: GitHubOAuthDevicePollRequest
   ): Promise<GitHubOAuthDevicePollResult>;
   getScopeDevboxOverview(): Promise<ScopeDevboxOverviewResult>;
+  createGitHubIssue(request: GitHubIssueCreateRequest): Promise<GitHubIssueMutationResult>;
   getGitHubRepositoryDetails(fullName: string): Promise<GitHubRepositoryDetailsResult>;
+  updateGitHubIssue(request: GitHubIssueUpdateRequest): Promise<GitHubIssueMutationResult>;
   startScopeDevboxJob(request: ScopeDevboxStartRequest): Promise<ScopeDevboxJobRecord>;
   stageGitPaths(request: GitStageRequest): Promise<GitActionResult>;
   deployProject(request: ProjectDeployRequest): Promise<GitActionResult>;


### PR DESCRIPTION
## Summary
- add Postgres to the Docker Compose stack so each environment has its own database service and volume
- persist GitHub OAuth tokens per Clerk user on the backend instead of per browser/local file
- add backend GitHub issue create/update endpoints
- add Web UI controls to create and edit issues
- keep Kanban loading layout fixed-width and horizontally scrollable

## Verification
- bun run check
- bun run build
- bun run check:cli
- git diff --check
- docker compose config renders db/web wiring
- local Issues page renders without console errors