### PR TITLE
Show deployment revision hashes

### DIFF
--- a/server/local-platform-operations.ts
+++ b/server/local-platform-operations.ts
@@ -57,6 +57,7 @@ function summarizeDeployment(entry: Record<string, unknown>): DeploymentRecordSu
     createdAt: String(entry.CreatedAt ?? entry.created_at ?? ''),
     environment: String(entry.EnvName ?? entry.environment ?? ''),
     id: String(entry.ID ?? entry.id ?? ''),
+    revision: String(entry.Revision ?? entry.revision ?? ''),
     routeHost: String(entry.RouteHost ?? entry.route_host ?? ''),
     routeKind: entry.RouteKind === 'public' ? 'public' : 'private',
     runtimeDir: String(entry.RuntimeDir ?? entry.runtime_dir ?? ''),

--- a/src/features/project-desktop/components/project-deployments-panel.tsx
+++ b/src/features/project-desktop/components/project-deployments-panel.tsx
@@ -162,6 +162,10 @@ function formatRunDuration(run: GitHubWorkflowRunSummary) {
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
+function shortRevision(revision?: string) {
+  return revision ? revision.slice(0, 7) : '';
+}
+
 function liveStatusLabel(deployment: DeploymentRecordSummary) {
   if (!deployment.live || deployment.live.status === 'unknown') {
     return 'not checked';
@@ -391,6 +395,11 @@ function DeploymentRow({ deployment, isLive = false, pipelineRun, repositoryUrl 
         ) : (
           <span>no source recorded</span>
         )}
+        {deployment.revision ? (
+          <span className="font-mono" title={deployment.revision}>
+            {shortRevision(deployment.revision)}
+          </span>
+        ) : null}
         <span title={formatDate(deployment.updatedAt || deployment.createdAt)}>
           deployed {formatRelativeTime(deployment.updatedAt || deployment.createdAt)}
         </span>

--- a/src/shared/project-space-api.ts
+++ b/src/shared/project-space-api.ts
@@ -533,6 +533,7 @@ export interface DeploymentRecordSummary {
     statusCode?: number;
     url?: string;
   };
+  revision?: string;
   routeHost?: string;
   routeKind?: DeploymentVisibility;
   runtimeDir?: string;


### PR DESCRIPTION
## Summary
- Include deployment revision hashes in platform overview responses
- Show the short revision in the deployments list so versions are visible

## Verification
- bun run check
- bun run build

Note: .claude/launch.json still has local debug changes and is intentionally not included.