### PR TITLE
Read deployment package versions from safe repo mount

### DIFF
--- a/server/local-platform-operations.ts
+++ b/server/local-platform-operations.ts
@@ -163,10 +163,14 @@ async function readLocalPackageVersionAtRevision(revision: string) {
   }
 
   try {
-    const { stdout } = await execFileAsync('git', ['-C', backendRepoPath, 'show', `${revision}:package.json`], {
-      timeout: 5_000,
-      windowsHide: true
-    });
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-c', `safe.directory=${backendRepoPath}`, '-C', backendRepoPath, 'show', `${revision}:package.json`],
+      {
+        timeout: 5_000,
+        windowsHide: true
+      }
+    );
 
     return packageVersionFromJson(stdout);
   } catch {
@@ -176,10 +180,14 @@ async function readLocalPackageVersionAtRevision(revision: string) {
 
 async function readCurrentLocalPackageVersion() {
   try {
-    const { stdout } = await execFileAsync('git', ['-C', backendRepoPath, 'show', 'HEAD:package.json'], {
-      timeout: 5_000,
-      windowsHide: true
-    });
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-c', `safe.directory=${backendRepoPath}`, '-C', backendRepoPath, 'show', 'HEAD:package.json'],
+      {
+        timeout: 5_000,
+        windowsHide: true
+      }
+    );
 
     return packageVersionFromJson(stdout);
   } catch {


### PR DESCRIPTION
## Summary
- Make the local git fallback work when the mounted repo has different ownership in Docker
- Keep package.json as the source for human-readable deployment versions

## Verification
- bun run check
- bun run build

Note: .claude/launch.json still has local debug changes and is intentionally not included.